### PR TITLE
feat(projects): self-service projects CMS for org members

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ After that server should be running on [localhost:3000](http://localhost:3000)
 
 > Warning: You could run into errors if you don't populate the `.env.local` with the correct values
 
-> Database: the Supabase schema the app expects (the `views` + `projects` tables
-> and the `views_sum()` function) lives in [`frontend/supabase/schema.sql`](frontend/supabase/schema.sql).
+> Database: the Supabase schema the app expects (the `views` table and the
+> `views_sum()` function) lives in [`frontend/supabase/schema.sql`](frontend/supabase/schema.sql).
 > Run it once in the Supabase SQL editor against your `SUPABASE_URL` project.
+> Packages and projects are stored in MongoDB (`MONGODB_URI`), not Supabase.

--- a/README.md
+++ b/README.md
@@ -84,4 +84,4 @@ After that server should be running on [localhost:3000](http://localhost:3000)
 > Database: the Supabase schema the app expects (the `views` table and the
 > `views_sum()` function) lives in [`frontend/supabase/schema.sql`](frontend/supabase/schema.sql).
 > Run it once in the Supabase SQL editor against your `SUPABASE_URL` project.
-> Packages and projects are stored in MongoDB (`MONGODB_URI`), not Supabase.
+> Packages and projects are stored in MongoDB (`MONGODB_URI` + `DB_NAME`), not Supabase.

--- a/frontend/components/OgImage.tsx
+++ b/frontend/components/OgImage.tsx
@@ -1,16 +1,17 @@
-import Image from "next/image";
+// Project cover images are user-submitted (any domain), so we render a plain
+// <img> rather than next/image — next/image throws on a non-allowlisted remote
+// hostname, which would 500 the whole /projects page for one bad cover URL.
 function OgImage({ src, alt }: { src: string; alt: string }) {
   return (
     <div className="relative -mt-[35%] sm:-mt-0 md:-ml-[35%] w-full sm:w-1/2 md:w-8/12 shrink-0 rounded-xl overflow-hidden shadow-2xl before:absolute before:inset-0 dark:before:bg-black/20 before:z-10">
-      <Image
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
         title={alt}
         alt={alt}
         src={src}
+        loading="lazy"
         width={1200}
         height={630}
-        placeholder="blur"
-        blurDataURL={src}
-        quality={25}
         className="transition-all duration-300 lg:group-hover:scale-110 backdrop-blur-xl"
         style={{
           width: "100%",

--- a/frontend/components/Project.tsx
+++ b/frontend/components/Project.tsx
@@ -5,9 +5,11 @@ import OgImage from "@components/OgImage";
 import { ProjectType } from "@lib/types";
 
 export default function Project({ project }: { project: ProjectType }) {
+  const cover = project.coverImage || "/images/sdv-blue-1200x1200.png";
+  const tools = project.tools ?? [];
   return (
     <div className="card">
-      <OgImage src={project?.coverImage as string} alt={project.name} />
+      <OgImage src={cover} alt={project.name} />
 
       <div className="flex flex-col justify-start gap-3">
         <h1 className="font-bold text-neutral-900 dark:text-neutral-200">
@@ -18,7 +20,7 @@ export default function Project({ project }: { project: ProjectType }) {
         </p>
 
         <div className="flex flex-wrap items-center gap-1">
-          {project.tools!.map((tool, index) => {
+          {tools.map((tool, index) => {
             return (
               <span
                 key={`${tool}-${index}`}

--- a/frontend/components/ProjectForm.tsx
+++ b/frontend/components/ProjectForm.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@components/ui/button";
+import type { ProjectInput, ProjectDoc } from "@lib/projectSchema";
+
+const fieldClass =
+  "w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/30 dark:border-gray-700 dark:bg-darkSecondary dark:text-gray-100";
+const labelClass =
+  "mb-1 block font-barlow text-sm font-semibold text-gray-700 dark:text-gray-200";
+
+type FormState = {
+  name: string;
+  description: string;
+  githubURL: string;
+  coverImage: string;
+  previewURL: string;
+  tools: string;
+  pinned: boolean;
+};
+
+function toFormState(initial?: Partial<ProjectDoc>): FormState {
+  return {
+    name: initial?.name ?? "",
+    description: initial?.description ?? "",
+    githubURL: initial?.githubURL ?? "",
+    coverImage: initial?.coverImage ?? "",
+    previewURL: initial?.previewURL ?? "",
+    tools: (initial?.tools ?? []).join(", "),
+    pinned: initial?.pinned ?? true,
+  };
+}
+
+export default function ProjectForm({
+  initial,
+  submitting,
+  onSubmit,
+  onCancel,
+}: {
+  initial?: Partial<ProjectDoc>;
+  submitting?: boolean;
+  onSubmit: (values: ProjectInput) => void;
+  onCancel?: () => void;
+}) {
+  const [form, setForm] = useState<FormState>(() => toFormState(initial));
+
+  function update<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((f) => ({ ...f, [key]: value }));
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const tools = form.tools
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+    onSubmit({
+      name: form.name.trim(),
+      description: form.description.trim(),
+      githubURL: form.githubURL.trim(),
+      coverImage: form.coverImage.trim() || undefined,
+      previewURL: form.previewURL.trim() || undefined,
+      tools,
+      pinned: form.pinned,
+    });
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-4 rounded-xl border border-gray-200 bg-white/80 p-6 shadow-sm dark:border-gray-700 dark:bg-darkSecondary/80"
+    >
+      <div>
+        <label className={labelClass} htmlFor="name">
+          Project name
+        </label>
+        <input
+          id="name"
+          className={fieldClass}
+          value={form.name}
+          onChange={(e) => update("name", e.target.value)}
+          placeholder="Game on Paper"
+          required
+        />
+      </div>
+
+      <div>
+        <label className={labelClass} htmlFor="description">
+          Description
+        </label>
+        <textarea
+          id="description"
+          className={`${fieldClass} min-h-[96px] resize-y`}
+          value={form.description}
+          onChange={(e) => update("description", e.target.value)}
+          placeholder="Live win probability, EPA, and advanced box scores for college football."
+          required
+        />
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div>
+          <label className={labelClass} htmlFor="githubURL">
+            Source repo URL
+          </label>
+          <input
+            id="githubURL"
+            type="url"
+            className={fieldClass}
+            value={form.githubURL}
+            onChange={(e) => update("githubURL", e.target.value)}
+            placeholder="https://github.com/sportsdataverse/..."
+            required
+          />
+        </div>
+        <div>
+          <label className={labelClass} htmlFor="previewURL">
+            Live preview URL (optional)
+          </label>
+          <input
+            id="previewURL"
+            type="url"
+            className={fieldClass}
+            value={form.previewURL}
+            onChange={(e) => update("previewURL", e.target.value)}
+            placeholder="https://gameonpaper.com/cfb"
+          />
+        </div>
+        <div className="sm:col-span-2">
+          <label className={labelClass} htmlFor="coverImage">
+            Cover image URL (optional)
+          </label>
+          <input
+            id="coverImage"
+            type="url"
+            className={fieldClass}
+            value={form.coverImage}
+            onChange={(e) => update("coverImage", e.target.value)}
+            placeholder="https://.../cover.png"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label className={labelClass} htmlFor="tools">
+          Tools / tech (comma-separated)
+        </label>
+        <input
+          id="tools"
+          className={fieldClass}
+          value={form.tools}
+          onChange={(e) => update("tools", e.target.value)}
+          placeholder="R, Python, Next.js, Cloudflare"
+        />
+      </div>
+
+      <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200">
+        <input
+          type="checkbox"
+          className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary/30"
+          checked={form.pinned}
+          onChange={(e) => update("pinned", e.target.checked)}
+        />
+        Visible on the projects page
+      </label>
+
+      <div className="flex items-center gap-3 pt-2">
+        <Button type="submit" disabled={submitting}>
+          {submitting ? "Saving…" : initial?._id ? "Save changes" : "Add project"}
+        </Button>
+        {onCancel ? (
+          <Button type="button" variant="ghost" onClick={onCancel} disabled={submitting}>
+            Cancel
+          </Button>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/frontend/lib/projectSchema.ts
+++ b/frontend/lib/projectSchema.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+/**
+ * Validation schema for a project entry (the MongoDB `projects` collection).
+ * Single source of truth for the *editable* fields — the API validates writes
+ * against it and the manage form is built from the same set.
+ *
+ * Server-managed fields (`_id`, `createdBy`, `updatedBy`, `createdAt`,
+ * `updatedAt`) are intentionally NOT here — the API stamps them and never
+ * trusts client-supplied values. `createdBy` (the creator's GitHub login) is
+ * the ownership key: members may edit/delete only their own projects.
+ */
+
+/** Optional URL: treats empty string / null as "absent". */
+const optionalUrl = z.preprocess(
+  (v) => (v === "" || v == null ? undefined : v),
+  z.string().trim().url("Must be a valid URL").optional()
+);
+
+export const projectSchema = z.object({
+  name: z.string().trim().min(1, "Project name is required").max(120),
+  description: z.string().trim().min(1, "Description is required").max(2000),
+  githubURL: z.string().trim().url("GitHub URL must be a valid URL"),
+  coverImage: optionalUrl,
+  previewURL: optionalUrl,
+  tools: z.array(z.string().trim().min(1).max(40)).max(20).optional(),
+  // No zod default: `projectSchema.partial()` (PUT) would otherwise re-inject
+  // pinned:true on every edit and un-hide a hidden project. The create-time
+  // default lives in the API instead.
+  pinned: z.boolean().optional(),
+});
+
+export type ProjectInput = z.infer<typeof projectSchema>;
+
+/** Partial variant for PUT (update) — every field optional. */
+export const projectUpdateSchema = projectSchema.partial();
+export type ProjectUpdateInput = z.infer<typeof projectUpdateSchema>;
+
+/** A persisted project document, including server-managed metadata. */
+export type ProjectDoc = ProjectInput & {
+  _id: string;
+  /** GitHub login of the creator — the ownership key for edit/delete. */
+  createdBy?: string;
+  updatedBy?: string;
+  createdAt?: string;
+  updatedAt?: string;
+};

--- a/frontend/lib/supabase.ts
+++ b/frontend/lib/supabase.ts
@@ -7,23 +7,6 @@ export const supabase = createClient(
 );
 
 /**
- * Asynchronously fetches all projects from the database where the 'pinned' column is set to true.
- * The results are sorted by the 'created_at' column in descending order.
- */
-export async function getProjects() {
-  let { data: projects, error } = await supabase
-    .from("projects")
-    .select("*")
-    .eq("pinned", "true")
-    .order("created_at", { ascending: false });
-
-  return {
-    projects,
-    error: error !== null,
-  };
-}
-
-/**
  * This function is used to add a view to the specified blog post. It first retrieves the blog post from the database
  * by its slug value. If the post exists, it increments the view count by 1 and updates it in the database.
  * If the post does not exist, it creates a new record with the slug and views set to 1.

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -13,14 +13,21 @@ export type AnimatedTAGProps = {
 };
 
 export type ProjectType = {
-  id: string;
+  // MongoDB document id; `id` retained as an optional legacy alias.
+  _id?: string;
+  id?: string;
   name: string;
-  coverImage: string;
+  coverImage?: string;
   description: string;
   githubURL: string;
   previewURL?: string;
   tools?: string[];
   pinned?: boolean;
+  // Server-managed metadata (createdBy is the owner / GitHub login).
+  createdBy?: string;
+  updatedBy?: string;
+  createdAt?: string;
+  updatedAt?: string;
 };
 
 export type SkillType = {

--- a/frontend/pages/api/projects.ts
+++ b/frontend/pages/api/projects.ts
@@ -1,0 +1,216 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+import { connectToDatabase } from "@lib/mongodb";
+import { ObjectId } from "mongodb";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@lib/auth";
+import { projectSchema, projectUpdateSchema } from "@lib/projectSchema";
+
+/**
+ * Coerce a request body to a plain object. Next parses JSON bodies into objects
+ * when `Content-Type: application/json`; tolerate a stringified body too.
+ */
+function parseBody(body: unknown): Record<string, any> {
+  if (body == null) return {};
+  if (typeof body === "string") {
+    try {
+      const parsed = JSON.parse(body);
+      return parsed && typeof parsed === "object" ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+  if (typeof body === "object") return body as Record<string, any>;
+  return {};
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  switch (req.method) {
+    case "GET": {
+      return getProjects(req, res);
+    }
+
+    case "POST":
+    case "PUT":
+    case "DELETE": {
+      // Writes require an authenticated sportsdataverse GitHub org member.
+      const session = await getServerSession(req, res, authOptions);
+      if (!session?.isOrgMember) {
+        return res.status(401).json({
+          message:
+            "Unauthorized: sign in with a sportsdataverse GitHub org account to manage projects.",
+          success: false,
+        });
+      }
+      const actor = session.login ?? "unknown";
+      const isAdmin = session.role === "admin";
+      if (req.method === "POST") return addProject(req, res, actor);
+      if (req.method === "PUT") return updateProject(req, res, actor, isAdmin);
+      return deleteProject(req, res, actor, isAdmin);
+    }
+
+    default: {
+      res.setHeader("Allow", "GET, POST, PUT, DELETE");
+      return res
+        .status(405)
+        .json({ message: "Method not allowed", success: false });
+    }
+  }
+}
+
+// Getting all projects (public, read-only).
+async function getProjects(_req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const { db } = await connectToDatabase();
+    const projects = await db
+      .collection("projects")
+      .find({})
+      .sort({ createdAt: -1 })
+      .toArray();
+    return res.json({
+      message: JSON.parse(JSON.stringify(projects)),
+      success: true,
+    });
+  } catch (error: any) {
+    return res
+      .status(500)
+      .json({ message: new Error(error).message, success: false });
+  }
+}
+
+// Adding a new project (owned by the creator).
+async function addProject(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  actor: string
+) {
+  const parsed = projectSchema.safeParse(parseBody(req.body));
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Validation failed",
+      errors: parsed.error.flatten(),
+      success: false,
+    });
+  }
+  try {
+    const { db } = await connectToDatabase();
+    const now = new Date().toISOString();
+    const doc = {
+      ...parsed.data,
+      // Visible on /projects by default; members can hide via the pinned toggle.
+      pinned: parsed.data.pinned ?? true,
+      createdBy: actor,
+      updatedBy: actor,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const result = await db.collection("projects").insertOne(doc);
+    return res.json({
+      message: "Project added successfully",
+      id: result.insertedId,
+      success: true,
+    });
+  } catch (error: any) {
+    return res
+      .status(500)
+      .json({ message: new Error(error).message, success: false });
+  }
+}
+
+/** Fetch a project and authorize the actor as owner or admin. */
+async function authorizeMutation(
+  db: Awaited<ReturnType<typeof connectToDatabase>>["db"],
+  id: string,
+  actor: string,
+  isAdmin: boolean
+): Promise<{ ok: true } | { ok: false; status: number; message: string }> {
+  const existing = await db
+    .collection("projects")
+    .findOne({ _id: new ObjectId(id) });
+  if (!existing) return { ok: false, status: 404, message: "Project not found." };
+  const isOwner = existing.createdBy && existing.createdBy === actor;
+  if (!isOwner && !isAdmin) {
+    return {
+      ok: false,
+      status: 403,
+      message: "You can only edit projects you created.",
+    };
+  }
+  return { ok: true };
+}
+
+// Updating a project by _id (owner or admin; validated fields only).
+async function updateProject(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  actor: string,
+  isAdmin: boolean
+) {
+  const { _id, ...rest } = parseBody(req.body);
+  if (!_id || typeof _id !== "string" || !ObjectId.isValid(_id)) {
+    return res.status(400).json({
+      message: "A valid _id is required to update a project.",
+      success: false,
+    });
+  }
+  const parsed = projectUpdateSchema.safeParse(rest);
+  if (!parsed.success) {
+    return res.status(400).json({
+      message: "Validation failed",
+      errors: parsed.error.flatten(),
+      success: false,
+    });
+  }
+  if (Object.keys(parsed.data).length === 0) {
+    return res
+      .status(400)
+      .json({ message: "No valid fields to update.", success: false });
+  }
+  try {
+    const { db } = await connectToDatabase();
+    const auth = await authorizeMutation(db, _id, actor, isAdmin);
+    if (!auth.ok) {
+      return res.status(auth.status).json({ message: auth.message, success: false });
+    }
+    await db.collection("projects").updateOne(
+      { _id: new ObjectId(_id) },
+      { $set: { ...parsed.data, updatedBy: actor, updatedAt: new Date().toISOString() } }
+    );
+    return res.json({ message: "Project updated successfully", success: true });
+  } catch (error: any) {
+    return res
+      .status(500)
+      .json({ message: new Error(error).message, success: false });
+  }
+}
+
+// Deleting a project by _id (owner or admin).
+async function deleteProject(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  actor: string,
+  isAdmin: boolean
+) {
+  const body = parseBody(req.body);
+  const id = typeof body._id === "string" ? body._id : undefined;
+  if (!id || !ObjectId.isValid(id)) {
+    return res.status(400).json({
+      message: "A valid _id is required to delete a project.",
+      success: false,
+    });
+  }
+  try {
+    const { db } = await connectToDatabase();
+    const auth = await authorizeMutation(db, id, actor, isAdmin);
+    if (!auth.ok) {
+      return res.status(auth.status).json({ message: auth.message, success: false });
+    }
+    await db.collection("projects").deleteOne({ _id: new ObjectId(id) });
+    return res.json({ message: "Project deleted successfully", success: true });
+  } catch (error: any) {
+    return res
+      .status(500)
+      .json({ message: new Error(error).message, success: false });
+  }
+}

--- a/frontend/pages/api/projects.ts
+++ b/frontend/pages/api/projects.ts
@@ -134,7 +134,7 @@ async function authorizeMutation(
     return {
       ok: false,
       status: 403,
-      message: "You can only edit projects you created.",
+      message: "You can only modify projects you created.",
     };
   }
   return { ok: true };

--- a/frontend/pages/projects.tsx
+++ b/frontend/pages/projects.tsx
@@ -1,11 +1,12 @@
 import React from "react";
+import Link from "next/link";
+import type { GetServerSidePropsContext } from "next";
 import Project from "@components/Project";
 import Metadata from "@components/MetaData";
 import PageTop from "@components/PageTop";
 import AnimatedDiv from "@components/FramerMotion/AnimatedDiv";
 import { FadeContainer } from "@content/FramerMotionVariants";
 import pageMeta from "@content/meta";
-import { getProjects } from "@lib/supabase";
 import { ProjectType } from "@lib/types";
 import CreateAnIssue from "@components/CreateAnIssue";
 
@@ -28,12 +29,11 @@ export default function Projects({
       />
       <section className="pageTop">
         <PageTop pageTitle="Projects">
-          I've been making various types of projects some of them were basics
-          and some of them were complicated. So far I've made{" "}
+          Projects from across the SportsDataverse community. So far there are{" "}
           <span className="font-bold text-gray-600 dark:text-gray-200">
             {projects.length}+
           </span>{" "}
-          projects.
+          projects on display.
         </PageTop>
 
         <AnimatedDiv
@@ -42,20 +42,47 @@ export default function Projects({
         >
           {projects.map((project) => {
             if (project.name === "" && project.githubURL === "") return null;
-            return <Project key={project.id} project={project} />;
+            return <Project key={project._id ?? project.id} project={project} />;
           })}
         </AnimatedDiv>
+
+        <div className="flex items-center justify-center px-5 pb-10 pt-8">
+          <Link
+            href="/projects/manage"
+            className="font-inter text-sm text-muted-foreground underline-offset-4 transition-colors hover:text-primary hover:underline dark:text-gray-400"
+          >
+            SportsDataverse org member? Add your project &rarr;
+          </Link>
+        </div>
       </section>
     </>
   );
 }
 
-export async function getStaticProps() {
-  const { projects, error } = await getProjects();
-  return {
-    props: {
-      projects,
-      error,
-    },
-  };
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
+  // Read the Mongo-backed projects from the public API on the same deployment.
+  const host = ctx.req.headers.host;
+  const proto =
+    (ctx.req.headers["x-forwarded-proto"] as string | undefined) ||
+    (host?.startsWith("localhost") ? "http" : "https");
+  const baseUrl = host
+    ? `${proto}://${host}`
+    : process.env.NODE_ENV !== "production"
+      ? process.env.DEV_URL
+      : process.env.PROD_URL;
+
+  let projects: ProjectType[] = [];
+  let error = false;
+  try {
+    const response = await fetch(`${baseUrl}/api/projects`);
+    if (!response.ok) throw new Error(`projects API ${response.status}`);
+    const data = await response.json();
+    const all: ProjectType[] = Array.isArray(data?.message) ? data.message : [];
+    // Show everything except entries explicitly hidden (pinned === false).
+    projects = all.filter((p) => p.pinned !== false);
+  } catch {
+    error = true;
+  }
+
+  return { props: { projects, error } };
 }

--- a/frontend/pages/projects/manage.tsx
+++ b/frontend/pages/projects/manage.tsx
@@ -170,6 +170,9 @@ export default function ManageProjects({
               {editing ? `Edit ${editing.name}` : "Add a new project"}
             </h2>
             <ProjectForm
+              // Remount on target change so the form never shows stale values
+              // when switching Add -> Edit or between different projects.
+              key={editing?._id ?? "new-project"}
               initial={editing ?? undefined}
               submitting={submitting}
               onSubmit={handleSubmit}

--- a/frontend/pages/projects/manage.tsx
+++ b/frontend/pages/projects/manage.tsx
@@ -1,0 +1,296 @@
+import { useState } from "react";
+import { useRouter } from "next/router";
+import Head from "next/head";
+import Link from "next/link";
+import type { GetServerSidePropsContext } from "next";
+import { getServerSession } from "next-auth/next";
+import { signIn, signOut } from "next-auth/react";
+import { Github, Pencil, Trash2, Plus } from "lucide-react";
+import { authOptions } from "@lib/auth";
+import { Button } from "@components/ui/button";
+import ProjectForm from "@components/ProjectForm";
+import type { ProjectInput, ProjectDoc } from "@lib/projectSchema";
+
+type ManageProps = {
+  authorized: boolean;
+  signedIn: boolean;
+  login: string | null;
+  isAdmin: boolean;
+  projects: ProjectDoc[];
+};
+
+export default function ManageProjects({
+  authorized,
+  signedIn,
+  login,
+  isAdmin,
+  projects,
+}: ManageProps) {
+  const router = useRouter();
+  const [editing, setEditing] = useState<ProjectDoc | null>(null);
+  const [adding, setAdding] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const canManage = (p: ProjectDoc) => isAdmin || (!!login && p.createdBy === login);
+
+  // --- Auth gate -----------------------------------------------------------
+  if (!authorized) {
+    return (
+      <>
+        <Head>
+          <title>Manage Projects · SportsDataverse</title>
+        </Head>
+        <div className="mx-auto flex min-h-[70vh] max-w-xl flex-col items-center justify-center gap-5 px-6 text-center">
+          <h1 className="bg-gradient-to-r from-primary via-accent to-primary bg-clip-text font-sarina text-3xl font-bold text-transparent">
+            Manage Projects
+          </h1>
+          {signedIn ? (
+            <p className="font-inter text-muted-foreground">
+              Your GitHub account isn&apos;t an active member of the{" "}
+              <span className="font-semibold">sportsdataverse</span> organization,
+              so you can&apos;t add projects. If you believe this is a mistake,
+              ask an org admin to confirm your membership.
+            </p>
+          ) : (
+            <p className="font-inter text-muted-foreground">
+              Members of the{" "}
+              <span className="font-semibold">sportsdataverse</span> GitHub
+              organization can show off their projects here. Sign in to continue.
+            </p>
+          )}
+          <div className="flex gap-3">
+            {signedIn ? (
+              <Button variant="outline" onClick={() => signOut()}>
+                Sign out
+              </Button>
+            ) : (
+              <Button onClick={() => signIn("github", { callbackUrl: "/projects/manage" })}>
+                <Github className="mr-2 h-4 w-4" /> Sign in with GitHub
+              </Button>
+            )}
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  // --- Mutations -----------------------------------------------------------
+  async function refresh() {
+    await router.replace(router.asPath, undefined, { scroll: false });
+  }
+
+  async function handleSubmit(values: ProjectInput) {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const isEdit = Boolean(editing?._id);
+      const res = await fetch("/api/projects", {
+        method: isEdit ? "PUT" : "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(isEdit ? { _id: editing!._id, ...values } : values),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.success) {
+        throw new Error(data.message || "Request failed");
+      }
+      setEditing(null);
+      setAdding(false);
+      await refresh();
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleDelete(project: ProjectDoc) {
+    if (!window.confirm(`Delete "${project.name}"? This cannot be undone.`)) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/projects", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ _id: project._id }),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.success) {
+        throw new Error(data.message || "Delete failed");
+      }
+      await refresh();
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  // --- Authorized view -----------------------------------------------------
+  return (
+    <>
+      <Head>
+        <title>Manage Projects · SportsDataverse</title>
+      </Head>
+      <div className="mx-auto max-w-4xl px-6 py-24">
+        <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="bg-gradient-to-r from-primary via-accent to-primary bg-clip-text font-sarina text-3xl font-bold text-transparent">
+              Manage Projects
+            </h1>
+            <p className="mt-1 font-inter text-sm text-muted-foreground">
+              Signed in as <span className="font-semibold">@{login}</span> · you
+              can edit the projects you add{isAdmin ? " (admin: any project)" : ""}.{" "}
+              <Link href="/packages/manage" className="text-primary hover:underline">
+                Manage packages →
+              </Link>
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {!adding && !editing ? (
+              <Button onClick={() => setAdding(true)}>
+                <Plus className="mr-2 h-4 w-4" /> Add project
+              </Button>
+            ) : null}
+            <Button variant="ghost" onClick={() => signOut()}>
+              Sign out
+            </Button>
+          </div>
+        </div>
+
+        {error ? (
+          <div className="mb-6 rounded-md border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300">
+            {error}
+          </div>
+        ) : null}
+
+        {(adding || editing) && (
+          <div className="mb-8">
+            <h2 className="mb-3 font-barlow text-xl font-semibold">
+              {editing ? `Edit ${editing.name}` : "Add a new project"}
+            </h2>
+            <ProjectForm
+              initial={editing ?? undefined}
+              submitting={submitting}
+              onSubmit={handleSubmit}
+              onCancel={() => {
+                setEditing(null);
+                setAdding(false);
+                setError(null);
+              }}
+            />
+          </div>
+        )}
+
+        <div className="space-y-3">
+          {projects.length === 0 ? (
+            <p className="font-inter text-muted-foreground">
+              No projects yet. Add the first one.
+            </p>
+          ) : (
+            projects.map((project) => (
+              <div
+                key={project._id}
+                className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-gray-200 bg-white/70 px-4 py-3 dark:border-gray-700 dark:bg-darkSecondary/70"
+              >
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-barlow text-lg font-semibold">
+                      {project.name}
+                    </span>
+                    {project.createdBy ? (
+                      <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary dark:bg-white/10 dark:text-sky-300">
+                        @{project.createdBy}
+                      </span>
+                    ) : null}
+                    {project.pinned === false ? (
+                      <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+                        Hidden
+                      </span>
+                    ) : null}
+                  </div>
+                  <p className="truncate font-inter text-sm text-muted-foreground">
+                    {project.description}
+                  </p>
+                </div>
+                {canManage(project) ? (
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label={`Edit ${project.name}`}
+                      onClick={() => {
+                        setEditing(project);
+                        setAdding(false);
+                        setError(null);
+                      }}
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label={`Delete ${project.name}`}
+                      onClick={() => handleDelete(project)}
+                    >
+                      <Trash2 className="h-4 w-4 text-red-600 dark:text-red-400" />
+                    </Button>
+                  </div>
+                ) : (
+                  <span className="text-xs text-muted-foreground">
+                    {project.createdBy ? `by @${project.createdBy}` : "—"}
+                  </span>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
+  const session = await getServerSession(ctx.req, ctx.res, authOptions);
+  const signedIn = Boolean(session);
+  const authorized = Boolean(session?.isOrgMember);
+
+  if (!authorized) {
+    return {
+      props: { authorized: false, signedIn, login: null, isAdmin: false, projects: [] },
+    };
+  }
+
+  // Read the listing from the public API on the SAME deployment (host-derived
+  // base URL — Vercel previews report NODE_ENV "production", so a DEV/PROD env
+  // switch would read prod while writes target the preview).
+  const host = ctx.req.headers.host;
+  const proto =
+    (ctx.req.headers["x-forwarded-proto"] as string | undefined) ||
+    (host?.startsWith("localhost") ? "http" : "https");
+  const baseUrl = host
+    ? `${proto}://${host}`
+    : process.env.NODE_ENV !== "production"
+      ? process.env.DEV_URL
+      : process.env.PROD_URL;
+  let projects: ProjectDoc[] = [];
+  try {
+    const response = await fetch(`${baseUrl}/api/projects`);
+    if (response.ok) {
+      const data = await response.json();
+      projects = Array.isArray(data?.message) ? data.message : [];
+    }
+  } catch {
+    projects = [];
+  }
+
+  return {
+    props: {
+      authorized: true,
+      signedIn,
+      login: session?.login ?? null,
+      isAdmin: session?.role === "admin",
+      projects,
+    },
+  };
+}

--- a/frontend/supabase/schema.sql
+++ b/frontend/supabase/schema.sql
@@ -1,7 +1,7 @@
 -- ---------------------------------------------------------------------------
 -- SportsDataverse web — Supabase schema
 -- ---------------------------------------------------------------------------
--- This is the database shape the app (frontend/lib/supabase.ts) expects. Run it
+-- This is the Supabase shape the app (frontend/lib/supabase.ts) expects. Run it
 -- once in the Supabase SQL editor (or via the Supabase CLI) against the project
 -- referenced by SUPABASE_URL / SUPABASE_KEY.
 --
@@ -9,69 +9,42 @@
 --   * `views`      — per-post view counter. Read + incremented on every blog
 --                    post via /api/views/[slug] (getViewBySlug / addView).
 --   * `views_sum()`— total view count, used by /api/views (getAllViews).
---   * `projects`   — pinned projects rendered on /projects (getProjects).
 --
--- Key choice: SUPABASE_KEY is server-only (used in API routes + getStaticProps,
--- never shipped to the client). Set it to the project's **service_role** key so
--- writes bypass RLS with no policies required. If you instead use the **anon**
--- key, uncomment the RLS section at the bottom.
+-- NOTE: the projects showcase no longer lives in Supabase — it moved to the
+-- MongoDB `projects` collection (see frontend/pages/api/projects.ts), which is
+-- the same store the packages CMS uses and supports org-member self-service.
 --
--- IMPORTANT: the `projects` columns coverImage / githubURL / previewURL are
--- created as QUOTED camelCase identifiers on purpose — the frontend reads them
--- straight off `select("*")` as project.coverImage etc., and unquoted Postgres
--- identifiers would fold to lowercase and break the mapping.
+-- Key choice: SUPABASE_KEY is server-only (used in API routes, never shipped to
+-- the client). Set it to the project's **service_role** key so writes bypass
+-- RLS with no policies required. If you instead use the **anon** key, uncomment
+-- the RLS section at the bottom.
 -- ---------------------------------------------------------------------------
 
--- gen_random_uuid() is built into Postgres 13+ core, but enable pgcrypto
--- explicitly so this also runs cleanly on older/stripped Postgres images.
-create extension if not exists pgcrypto;
-
--- 1. Per-post view counter --------------------------------------------------
+-- Per-post view counter -----------------------------------------------------
 create table if not exists public.views (
   slug       text primary key,
   views      bigint not null default 0,
   created_at timestamptz not null default now()
 );
 
--- 2. Total-views RPC (getAllViews) ------------------------------------------
+-- Total-views RPC (getAllViews) ---------------------------------------------
 create or replace function public.views_sum()
 returns bigint
 language sql
 stable
 as $$ select coalesce(sum(views), 0) from public.views; $$;
 
--- 3. Pinned projects for /projects ------------------------------------------
-create table if not exists public.projects (
-  id            uuid primary key default gen_random_uuid(),
-  name          text not null default '',
-  description   text not null default '',
-  "coverImage"  text not null default '',
-  "githubURL"   text not null default '',
-  "previewURL"  text,
-  tools         text[] not null default '{}',
-  pinned        boolean not null default false,
-  created_at    timestamptz not null default now()
-);
-
--- getProjects() filters on pinned = true and orders by created_at desc, so an
--- index there keeps the projects page query cheap.
-create index if not exists projects_pinned_created_at_idx
-  on public.projects (pinned, created_at desc);
-
 -- ---------------------------------------------------------------------------
 -- RLS — ONLY needed if SUPABASE_KEY is the anon (public) key. With the
 -- service_role key these are unnecessary (RLS is bypassed). Uncomment to use:
 -- ---------------------------------------------------------------------------
--- alter table public.views    enable row level security;
--- alter table public.projects enable row level security;
+-- alter table public.views enable row level security;
 --
--- create policy "views readable"    on public.views    for select using (true);
--- create policy "views insertable"  on public.views    for insert with check (true);
--- create policy "views updatable"   on public.views    for update using (true);
--- create policy "projects readable" on public.projects for select using (true);
+-- create policy "views readable"   on public.views for select using (true);
+-- create policy "views insertable" on public.views for insert with check (true);
+-- create policy "views updatable"  on public.views for update using (true);
 --
 -- Policies gate row access, but the roles still need table-level privileges or
 -- PostgREST returns a permission error even with policies in place:
--- grant select, insert, update on public.views    to anon, authenticated;
--- grant select                 on public.projects to anon, authenticated;
+-- grant select, insert, update on public.views to anon, authenticated;
 -- grant execute on function public.views_sum() to anon, authenticated;


### PR DESCRIPTION
Adds a self-service **projects** showcase: members of the `sportsdataverse`
GitHub org sign in and add / edit / delete projects on `/projects`.

Built as a sibling of the packages CMS (same GitHub-OAuth org gate + hardened,
zod-validated write API) but **MongoDB-backed** and **owner-scoped**.

### Auth & API (`pages/api/projects.ts`)
- `GET` public; `POST/PUT/DELETE` require an active org member (`getServerSession` + `isOrgMember`)
- **Owner-scoped:** `PUT`/`DELETE` additionally require you to be the creator (`createdBy`) **or** an org admin
- zod validation + field allowlist; server stamps `createdBy`/`updatedBy`/timestamps; `_id` never trusted

### UI
- `/projects/manage` — gated CMS (list + add/edit/delete; edit/delete shown only on your own, admins see all), cross-linked with `/packages/manage`
- `ProjectForm` (zod-backed, comma-separated tools); discovery CTA on `/projects`
- `/projects` now reads the Mongo API via SSR, so member additions appear live

### Storage move + hardening
- Projects moved **off Supabase → MongoDB** (consistent with packages): removed `getProjects` and the Supabase `projects` table from `schema.sql` (the `views` counter stays); README updated
- `Project` card guards `tools`/`coverImage`, and `OgImage` now renders a plain `<img>` so an arbitrary member cover URL can't 500 `/projects` via `next/image`'s hostname allowlist

No new env or deps — reuses `MONGODB_URI` and the existing NextAuth setup.

Verification: `next build` green (25/25), `tsc` + `eslint .` clean.
