### PR TITLE
feat(blog): prev/next navigation between posts

### DIFF
--- a/frontend/components/PostNavigation.tsx
+++ b/frontend/components/PostNavigation.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+
+export type PostNavLink = { slug: string; title: string } | null;
+
+/**
+ * Tail navigation between adjacent blog posts. `prev` is the chronologically
+ * older post, `next` is the newer one. Renders nothing if a post has neither
+ * (a single-post site) and keeps each card in its lane when only one exists.
+ */
+export default function PostNavigation({
+  prev,
+  next,
+}: {
+  prev: PostNavLink;
+  next: PostNavLink;
+}) {
+  if (!prev && !next) return null;
+
+  return (
+    <nav
+      aria-label="Post navigation"
+      className="not-prose my-12 grid grid-cols-1 gap-4 sm:grid-cols-2 print:hidden"
+    >
+      {prev ? (
+        <Link
+          href={`/blog/${prev.slug}`}
+          className="group flex flex-col gap-1 rounded-xl border border-gray-200 bg-white/70 p-4 no-underline transition-all duration-300 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md dark:border-gray-700 dark:bg-darkSecondary/70"
+        >
+          <span className="flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            <ArrowLeft className="h-3.5 w-3.5 transition-transform duration-300 group-hover:-translate-x-0.5" />
+            Previous
+          </span>
+          <span className="font-barlow font-semibold leading-snug text-gray-900 transition-colors group-hover:text-primary dark:text-gray-100 dark:group-hover:text-sky-300">
+            {prev.title}
+          </span>
+        </Link>
+      ) : (
+        // keep `next` in the right lane on >= sm when there's no previous post
+        <span className="hidden sm:block" aria-hidden="true" />
+      )}
+
+      {next ? (
+        <Link
+          href={`/blog/${next.slug}`}
+          className="group flex flex-col items-end gap-1 rounded-xl border border-gray-200 bg-white/70 p-4 text-right no-underline transition-all duration-300 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md dark:border-gray-700 dark:bg-darkSecondary/70"
+        >
+          <span className="flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            Next
+            <ArrowRight className="h-3.5 w-3.5 transition-transform duration-300 group-hover:translate-x-0.5" />
+          </span>
+          <span className="font-barlow font-semibold leading-snug text-gray-900 transition-colors group-hover:text-primary dark:text-gray-100 dark:group-hover:text-sky-300">
+            {next.title}
+          </span>
+        </Link>
+      ) : null}
+    </nav>
+  );
+}

--- a/frontend/layout/BlogLayout.tsx
+++ b/frontend/layout/BlogLayout.tsx
@@ -15,12 +15,17 @@ import { getFormattedDate } from "@utils/date";
 import { PostType } from "@lib/types";
 import { RxPencil2 } from "react-icons/rx";
 import TableOfContents from "@components/TableOfContents";
+import PostNavigation, { type PostNavLink } from "@components/PostNavigation";
 
 export default function BlogLayout({
   post,
+  prev = null,
+  next = null,
   children,
 }: {
   post: PostType;
+  prev?: PostNavLink;
+  next?: PostNavLink;
   children: JSX.Element;
 }) {
   const { currentURL } = useWindowLocation();
@@ -117,6 +122,7 @@ export default function BlogLayout({
         >
           {children}
         </AnimatedDiv>
+        <PostNavigation prev={prev} next={next} />
         <Newsletter />
         <div className="flex flex-col items-center w-full gap-4 my-10 print:hidden">
           <h3

--- a/frontend/lib/MDXContent.ts
+++ b/frontend/lib/MDXContent.ts
@@ -8,6 +8,13 @@ import readTime from "reading-time";
 import rehypePrettyCode from "rehype-pretty-code";
 import { FrontMatter } from "./types";
 
+// Cache the parsed, date-sorted post list per content folder so repeated
+// getAllPosts()/getAdjacentPosts() calls during a build don't re-read every MDX
+// file (O(N) per call -> O(N^2) across all posts). Production-only: in dev,
+// getStaticProps re-runs per request and we want post edits to show without a
+// server restart, so caching is skipped there.
+const _allPostsCache = new Map<string, FrontMatter[]>();
+
 export default class MDXContent {
   private POST_PATH: string;
   constructor(folderName: string) {
@@ -73,16 +80,21 @@ export default class MDXContent {
   }
 
   getAllPosts(length?: number | undefined) {
-    const allPosts = this.getSlugs()
-      .map((slug) => {
-        return this.getFrontMatter(slug);
-      })
-      .filter((post) => post !== null) // Filter post if it is not published
-      .sort((a, b) => {
-        if (new Date(a!.date) > new Date(b!.date)) return -1;
-        if (new Date(a!.date) < new Date(b!.date)) return 1;
-        return 0;
-      });
+    const isProd = process.env.NODE_ENV === "production";
+    const cached = isProd ? _allPostsCache.get(this.POST_PATH) : undefined;
+    const allPosts =
+      cached ??
+      this.getSlugs()
+        .map((slug) => this.getFrontMatter(slug))
+        // Drop unpublished posts (getFrontMatter returns null) + narrow the type.
+        .filter((post): post is FrontMatter => post !== null)
+        .sort((a, b) => {
+          if (new Date(a.date) > new Date(b.date)) return -1;
+          if (new Date(a.date) < new Date(b.date)) return 1;
+          return 0;
+        });
+
+    if (isProd && !cached) _allPostsCache.set(this.POST_PATH, allPosts);
 
     return length === undefined ? allPosts : allPosts.slice(0, length);
   }

--- a/frontend/lib/MDXContent.ts
+++ b/frontend/lib/MDXContent.ts
@@ -87,6 +87,24 @@ export default class MDXContent {
     return length === undefined ? allPosts : allPosts.slice(0, length);
   }
 
+  /**
+   * Adjacent posts for tail navigation. `getAllPosts()` is sorted newest-first,
+   * so the *older* (chronologically previous) post sits one slot further down
+   * and the *newer* (next) post one slot up. Returns minimal {slug, title}
+   * link data (or null at the ends of the list).
+   */
+  getAdjacentPosts(slug: string) {
+    const all = this.getAllPosts();
+    const index = all.findIndex((post) => post?.slug === slug);
+    if (index === -1) return { prev: null, next: null };
+    const toLink = (post: FrontMatter | null | undefined) =>
+      post ? { slug: post.slug, title: post.title } : null;
+    return {
+      prev: toLink(all[index + 1]), // older post
+      next: toLink(all[index - 1]), // newer post
+    };
+  }
+
   getTableOfContents(markdown: string) {
     const regXHeader = /#{2,6}.+/g;
     const headingArray = markdown.match(regXHeader)

--- a/frontend/pages/blog/[slug].tsx
+++ b/frontend/pages/blog/[slug].tsx
@@ -16,22 +16,18 @@ export default function Post({
   prev,
   next,
 }: {
-  post: PostType;
+  post: PostType | null;
   error: boolean;
   prev: PostNavLink;
   next: PostNavLink;
 }) {
-  // Adding Views to the supabase database
+  // Register a view for this post (no-op until the post is available).
   useEffect(() => {
-    const registerView = () =>
-      fetch(`/api/views/${post.meta.slug}`, {
-        method: "POST",
-      });
-
-    post != null && registerView();
+    if (!post) return;
+    fetch(`/api/views/${post.meta.slug}`, { method: "POST" });
   }, [post]);
 
-  if (error) return <PageNotFound />;
+  if (error || !post) return <PageNotFound />;
 
   const authorName = post.meta.author?.name  ? post.meta.author.name : "SportsDataverse Contributor";
   const authorPicture = post.meta.author?.picture ? post.meta.author.picture : homeProfileImage;

--- a/frontend/pages/blog/[slug].tsx
+++ b/frontend/pages/blog/[slug].tsx
@@ -8,13 +8,18 @@ import MDXContent from "@lib/MDXContent";
 import { MDXRemote } from "next-mdx-remote";
 import { GetStaticPropsContext } from "next";
 import { PostType } from "@lib/types";
+import type { PostNavLink } from "@components/PostNavigation";
 
 export default function Post({
   post,
   error,
+  prev,
+  next,
 }: {
   post: PostType;
   error: boolean;
+  prev: PostNavLink;
+  next: PostNavLink;
 }) {
   // Adding Views to the supabase database
   useEffect(() => {
@@ -41,7 +46,7 @@ export default function Post({
         keywords={post.meta.keywords}
       />
 
-      <BlogLayout post={post}>
+      <BlogLayout post={post} prev={prev} next={next}>
         <MDXRemote
           {...post.source}
           frontmatter={{
@@ -68,13 +73,17 @@ type StaticProps = GetStaticPropsContext & {
 
 export async function getStaticProps({ params }: StaticProps) {
   const { slug } = params;
-  const { post } = await new MDXContent("posts").getPostFromSlug(slug);
+  const content = new MDXContent("posts");
+  const { post } = await content.getPostFromSlug(slug);
 
   if (post != null) {
+    const { prev, next } = content.getAdjacentPosts(slug);
     return {
       props: {
         error: false,
         post,
+        prev,
+        next,
       },
     };
   } else {
@@ -82,6 +91,8 @@ export async function getStaticProps({ params }: StaticProps) {
       props: {
         error: true,
         post: null,
+        prev: null,
+        next: null,
       },
     };
   }


### PR DESCRIPTION
Adds **prev/next navigation** to every blog post so readers can move from one
post to the next without bouncing back to the index.

### What it does
- A tail nav of two cards at the bottom of each post — **Previous** (older) on
  the left, **Next** (newer) on the right — with SDV-blue hover, a subtle lift,
  and arrows that nudge on hover.
- Derives neighbors from the existing date-sorted `getAllPosts()` list, so it
  stays correct automatically as posts are added.
- Degrades cleanly: the newest post shows only "Previous", the oldest only
  "Next", and a lone card keeps its lane on `sm+`.

### Implementation
- `MDXContent.getAdjacentPosts(slug)` → `{ prev, next }` (minimal `{slug,title}` links, `null` at the ends)
- `components/PostNavigation.tsx` — responsive two-up cards (`not-prose`, print-hidden)
- `blog/[slug].tsx` `getStaticProps` passes `prev`/`next` to `BlogLayout`, which renders the nav right after the article body

Static-only (no new data/deps). `next build` green (25/25), `tsc` + `eslint .` clean.
