### PR TITLE
feat(platform): members-only automation/dataset/model-run/database platform

### DIFF
--- a/docs/superpowers/specs/2026-07-11-platform-design.md
+++ b/docs/superpowers/specs/2026-07-11-platform-design.md
@@ -1,0 +1,169 @@
+# SDV Platform — automation / dataset / model-run tracking & evaluation (design)
+
+**Date:** 2026-07-11 · **Repo:** sportsdataverse-web · **Branch:** `feat/platform`
+**Mode:** autonomous (goal-directed session). Design decisions are recorded here with
+rationale; the PR is the human review gate.
+
+## Goal
+
+An org-members-only **`/platform`** area of sportsdataverse.org, behind the existing
+GitHub-OAuth (NextAuth) layer, covering four pillars:
+
+1. **Automation** — see the org's scheduled GitHub Actions pipelines (scrapers,
+   data builders, live-test crons) across the data repos: latest run status,
+   history, and a "run now" (`workflow_dispatch`) button.
+2. **Datasets** — a registry of the `*-data` release artifacts: per-repo releases,
+   assets, sizes, updated timestamps, links.
+3. **Model training / tracking** — a run-tracking store (MongoDB) with a CI-friendly
+   ingest API: training jobs POST a run record (params, metrics, oracle gates,
+   artifacts, git provenance); the UI lists models and their runs.
+4. **Evaluation** — per-model views: metric history across runs, oracle-gate
+   pass/fail matrix, run detail with full payload.
+
+## Non-goals (YAGNI)
+
+- No artifact storage/upload (artifacts are links to GitHub releases — the org's
+  established pattern for model bundles, e.g. `nfl_model_artifacts`).
+- No experiment orchestration from the browser beyond `workflow_dispatch`.
+- No per-user RBAC beyond the existing org-member boundary (all members equal,
+  matching `/packages/manage` + `/projects/manage`).
+- No charting library dependency — metric trends render as small inline SVG
+  sparklines (hand-rolled, ~40 lines), keeping the bundle lean.
+- No test framework introduction — the repo has none; the verification gate is
+  `npm run tsc` + `npm run lint` + `npm run build` (matches existing practice).
+
+## Approaches considered
+
+- **A (chosen): build inside sdv-web** — Pages Router pages + API routes,
+  NextAuth org-member gate, MongoDB for run tracking, GitHub REST for
+  automation/datasets. Reuses every established pattern (`lib/auth.ts`
+  `isOrgMember`, `pages/api/packages.ts` gating shape, `lib/mongodb.ts`,
+  zod schemas in `lib/`, shadcn/Tailwind UI). Zero new infra.
+- **B: self-hosted MLflow / W&B linked from the site** — richer tracking, but
+  new infra to run/secure, not "part of the website", and the org's models are
+  gate-driven (oracle gates) rather than epoch-loss-driven; MLflow's model is a
+  poor fit. Rejected.
+- **C: static dashboards from CI-committed JSON** — no auth story, no ingest,
+  stale between crons. Rejected.
+
+## Architecture
+
+```
+frontend/
+  content/platform.ts            # tracked-repo config (single source of truth)
+  lib/platform/schemas.ts        # zod: ModelRun ingest/query schemas + TS types
+  lib/platform/github.ts         # server-only GitHub REST helpers (runs, releases, dispatch)
+  lib/platform/auth.ts           # requirePlatformSession / ingest-token check
+  pages/api/platform/
+    automation.ts                # GET workflows+latest runs | POST dispatch
+    datasets.ts                  # GET releases summary per tracked repo
+    runs.ts                      # GET run list (filters) | POST ingest
+    runs/[id].ts                 # GET one | DELETE (org member)
+    models.ts                    # GET registry (aggregate runs by model_id)
+  pages/platform/
+    index.tsx                    # overview: pillar cards + recent activity
+    automation.tsx               # workflow dashboard + dispatch
+    datasets.tsx                 # dataset/release registry
+    models/index.tsx             # model registry
+    models/[modelId].tsx         # evaluation: metric trends + gate matrix + runs
+    runs/[id].tsx                # run detail
+  components/platform/           # PlatformShell, StatusBadge, GateBadge,
+                                 # Sparkline, RunTable, shared bits
+docs (repo root): SETUP-platform.md   # env vars, PAT scopes, CI ingest recipe
+```
+
+### Auth model
+
+- **Every `/platform` page** is gated in `getServerSideProps` via
+  `getServerSession`; non-members get an in-page sign-in/join prompt (renders a
+  minimal "members only" state rather than redirecting, matching `/packages/manage`).
+- **Every `/api/platform/*` route requires an org-member session** — including
+  GETs (the platform is private, unlike public `/api/packages` GET).
+- **Exception:** `POST /api/platform/runs` (ingest) additionally accepts
+  `Authorization: Bearer <PLATFORM_INGEST_TOKEN>` (timing-safe compare) so CI
+  training jobs can log runs without a browser session. Fails closed when the
+  env var is unset.
+
+### GitHub access
+
+- `GH_PLATFORM_TOKEN` (server-only env): fine-grained PAT with `actions:read`
+  (+ `actions:write` for dispatch) on the org repos. Read endpoints fall back
+  to unauthenticated GitHub REST (public repos work, rate-limited) when unset;
+  `workflow_dispatch` returns 503 with a clear message when unset.
+- All GitHub calls happen server-side in API routes (token never ships to the
+  client); client pages fetch via SWR from `/api/platform/*`.
+
+### Data model — `model_runs` collection (MongoDB)
+
+```jsonc
+{
+  "model_id": "nfl_ep",              // stable slug, groups runs into a "model"
+  "sport": "nfl",                    // nfl|cfb|nba|wnba|mbb|wbb|mlb|nhl|multi
+  "run_name": "era-retrain-2026-07", // human label (optional)
+  "status": "completed",             // running|completed|failed
+  "params": { "eta": 0.025 },        // flat map, numbers/strings/bools
+  "metrics": { "ep_corr": 0.996 },   // flat map, numbers
+  "gates": [                          // oracle gates — the org's eval currency
+    { "name": "ep_corr_vs_nflfastr", "threshold": 0.99, "observed": 0.996,
+      "comparison": "gte", "passed": true }
+  ],
+  "artifacts": [{ "name": "ep_model.ubj", "url": "https://github.com/..." }],
+  "git": { "repo": "sportsdataverse/nfl-data", "branch": "main", "sha": "..." },
+  "tags": ["era-aware"],
+  "notes": "optional markdown-ish text",
+  "started_at": "ISO", "finished_at": "ISO",
+  "created_by": "ci|<gh login>", "created_at": "ISO", "updated_at": "ISO"
+}
+```
+
+Zod-validated on ingest; server stamps `created_by/created_at/updated_at` and
+ignores client `_id`. The **model registry** is an aggregation (`$group` by
+`model_id`): latest run, run count, latest gate summary, sports.
+
+### Tracked repos (`content/platform.ts`)
+
+A typed list of the org's automation/data repos, each with: `repo`,
+`kind: "raw" | "data" | "package"`, `sport`, and optional
+`workflows: string[]` allowlist (only allowlisted workflow files may be
+dispatched — prevents dispatching arbitrary workflows). Seeded with the known
+producers (nfl-raw/nfl-data, cfbfastR-raw/-data, hoopR/wehoop mirrors,
+fastRhockey, sdv-py live-tests cron, sportsdataverse-data). Editing the list is
+a code change — deliberate, reviewable.
+
+### Error handling
+
+- Auth failures: 401 JSON `{ message, success: false }` (existing shape).
+- Zod failures: 400 with `errors: flatten()` (existing shape).
+- GitHub REST failures: the API route returns 502 with the upstream status;
+  pages render a non-fatal banner per section (one failing repo doesn't blank
+  the dashboard — `Promise.allSettled` per repo).
+- Mongo failures: 500, existing shape.
+
+### UI
+
+- `PlatformShell`: authenticated layout wrapper — left tab nav
+  (Overview / Automation / Datasets / Models), session badge, sign-out.
+  Reuses `Layout.tsx` + Tailwind + shadcn button/card idioms and dark mode.
+- Status/gate badges: green/amber/red chips (lucide icons); sparklines are
+  inline SVG. SWR for data with refresh intervals on the automation page.
+
+## Phases (implementation order)
+
+1. **Foundation** — config, schemas, platform auth helper, PlatformShell,
+   gated `/platform` overview page, nav entry, env example updates.
+2. **Automation** — GitHub helpers + `automation` API + dashboard + dispatch.
+3. **Datasets** — releases API + registry page.
+4. **Runs/Models** — ingest+query APIs, runs UI, model registry.
+5. **Evaluation** — model detail (trends, gate matrix), run detail.
+6. **Docs & verification** — SETUP-platform.md, CI ingest recipe (Python +
+   `curl`), `tsc`/`lint`/`build` green, PR.
+
+## Success criteria
+
+- Signed-out / non-member users see a members-only prompt on every
+  `/platform` page and 401 from every `/api/platform/*` call.
+- An org member can: watch workflow statuses, dispatch an allowlisted
+  workflow, browse dataset releases, and browse models/runs.
+- A CI job can `POST /api/platform/runs` with the ingest bearer token and the
+  run appears in the UI with gates rendered pass/fail.
+- `npm run tsc`, `npm run lint`, `npm run build` all pass.

--- a/docs/superpowers/specs/2026-07-11-platform-design.md
+++ b/docs/superpowers/specs/2026-07-11-platform-design.md
@@ -56,7 +56,7 @@ GitHub-OAuth (NextAuth) layer, covering four pillars:
 
 ## Architecture
 
-```
+```text
 frontend/
   content/platform.ts            # tracked-repo config (single source of truth)
   lib/platform/schemas.ts        # zod: ModelRun ingest/query schemas + TS types

--- a/docs/superpowers/specs/2026-07-11-platform-design.md
+++ b/docs/superpowers/specs/2026-07-11-platform-design.md
@@ -19,6 +19,14 @@ GitHub-OAuth (NextAuth) layer, covering four pillars:
    artifacts, git provenance); the UI lists models and their runs.
 4. **Evaluation** — per-model views: metric history across runs, oracle-gate
    pass/fail matrix, run detail with full payload.
+5. **Database** (added mid-build per user request) — status of the Postgres
+   warehouse on the sdv-data droplet. Its ports are deliberately closed to the
+   public internet (post-incident hardening, 2026-07-08), so the site never
+   dials the DB: a daily cron on the droplet PUSHES a heartbeat
+   (`POST /api/platform/db-status`, ingest bearer token) with size/table/row
+   stats + per-dataset freshness; the UI renders the latest snapshot per
+   `source` (Mongo `db_status` collection, upserted) and flags heartbeats
+   older than 26 h as stale.
 
 ## Non-goals (YAGNI)
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -59,3 +59,16 @@ NEXTAUTH_URL=http://localhost:3000
 # Org membership is read with the signed-in user's own OAuth token
 # (scope `read:org`), so no separate server PAT is required.
 # The legacy PACKAGES_SECRET (single shared write key) is no longer used.
+
+# --- Platform (/platform — members-only) -------------------------------------
+# Fine-grained PAT used server-side for the Automation + Datasets tabs and
+# workflow_dispatch. Scopes: actions:read (+ actions:write to enable the "Run"
+# buttons) on the sportsdataverse repos. Optional — reads fall back to
+# unauthenticated GitHub API calls (60 req/h); dispatch is disabled when unset.
+GH_PLATFORM_TOKEN=
+
+# Bearer token CI jobs use to POST model runs / db-status heartbeats to
+# /api/platform/runs and /api/platform/db-status. Generate with:
+#   openssl rand -hex 32
+# Ingest is disabled (session-only) when unset.
+PLATFORM_INGEST_TOKEN=

--- a/frontend/SETUP-platform.md
+++ b/frontend/SETUP-platform.md
@@ -42,7 +42,7 @@ without `PLATFORM_INGEST_TOKEN` token ingest is disabled (session-only writes).
 ## Recording a model run from CI / a training script
 
 ```sh
-curl -sS -X POST "$PROD_URL/api/platform/runs" \
+curl -sS -X POST "$SDV_PLATFORM_URL/api/platform/runs" \
   -H "Authorization: Bearer $PLATFORM_INGEST_TOKEN" \
   -H "Content-Type: application/json" \
   -d @- << 'JSON'
@@ -95,31 +95,41 @@ timestamps are ISO-8601 with offset.
 
 The site never dials Postgres — the droplet's DB ports stay closed to the
 public internet. A daily cron on the droplet pushes a snapshot instead
-(anything older than 26 h renders as **stale**):
+(anything older than 26 h renders as **stale**).
 
-```sh
-#!/usr/bin/env bash
-# /opt/sdv-db/heartbeat.sh — cron: 15 6 * * *
-set -euo pipefail
-PSQL="psql -U postgres -d sdv -tA"
-curl -sS -X POST "$SDV_PLATFORM_URL/api/platform/db-status" \
-  -H "Authorization: Bearer $PLATFORM_INGEST_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d "$(jq -n \
-    --arg version "$($PSQL -c 'show server_version')" \
-    --argjson size "$($PSQL -c "select pg_database_size('sdv')")" \
-    --argjson tables "$($PSQL -c "select count(*) from information_schema.tables where table_schema not in ('pg_catalog','information_schema')")" \
-    --argjson rows "$($PSQL -c "select coalesce(sum(n_live_tup),0) from pg_stat_user_tables")" \
-    '{source: "sdv-db", ok: true, host_label: "sdv-data droplet",
-      postgres_version: $version, db_size_bytes: $size,
-      table_count: $tables, row_estimate: $rows,
-      collected_at: (now | todate)}')"
+The canonical heartbeat lives in the **sdv-db** repo as a CLI command
+(`sdv_db/heartbeat.py`, run as `uv run sdv-db heartbeat`; `--dry-run` prints
+the payload without POSTing). It reports the global stats plus a per-dataset
+`datasets[]` array (≤200 entries) the Database tab renders as a freshness
+table:
+
+```jsonc
+{
+  "source": "sdv-db", "ok": true, "host_label": "sdv-data droplet",
+  "postgres_version": "17.x", "db_size_bytes": 63350000000,
+  "table_count": 79, "row_estimate": 112800000,
+  "datasets": [
+    { "name": "nfl.pbp", "rows": 1200000,
+      "last_updated": "2026-07-11T06:15:00+00:00",   // when it last gained rows
+      "latest_row": "game_id=2026_01_KC_BUF (2026-01-13)" }  // newest row identity
+  ],
+  "collected_at": "2026-07-11T06:15:02+00:00"
+}
 ```
 
-Optionally add a `datasets: [{name, rows, last_updated}]` array (≤200 entries)
-for per-dataset freshness — the Database tab renders it as a table. On failure,
-POST `{"source": "sdv-db", "ok": false, "error": "...", "collected_at": ...}`
-so the outage is visible rather than silently stale.
+`last_updated` is the max of the table's event/load timestamp column;
+`latest_row` is a short human-readable identity of the newest row (key +
+event date). On failure the script POSTs
+`{"source": "sdv-db", "ok": false, "error": "...", "collected_at": ...}` so an
+outage is visible rather than silently stale.
+
+Cron wiring on the droplet:
+
+```sh
+# /etc/cron.d/sdv-platform-heartbeat
+15 6 * * * sdv cd /opt/sdv-db/python && SDV_PLATFORM_URL=https://sportsdataverse.org \
+  PLATFORM_INGEST_TOKEN=<token> uv run sdv-db heartbeat >> /var/log/sdv-heartbeat.log 2>&1
+```
 
 ## GitHub PAT for the Automation/Datasets tabs
 

--- a/frontend/SETUP-platform.md
+++ b/frontend/SETUP-platform.md
@@ -1,0 +1,135 @@
+# Platform (`/platform`) — setup
+
+The members-only platform area covers five surfaces, all behind the existing
+GitHub-OAuth (NextAuth) layer — active **`sportsdataverse`** org members only,
+same trust boundary as `/packages/manage`:
+
+| Tab | Source | What it shows |
+| --- | --- | --- |
+| Automation | GitHub Actions API | Workflow status per tracked repo + manual `workflow_dispatch` |
+| Datasets | GitHub Releases API | Release artifacts across the `*-data` repos |
+| Models | MongoDB `model_runs` | Training runs: params, metrics, oracle gates, artifacts |
+| (Model detail) | MongoDB `model_runs` | Metric trends, gate pass/fail matrix per model |
+| Database | MongoDB `db_status` | Postgres heartbeats pushed by the sdv-data droplet |
+
+Design doc: `docs/superpowers/specs/2026-07-11-platform-design.md` (repo root).
+
+## Auth model
+
+- Every `/platform` page and `/api/platform/*` route (GETs included) requires
+  an org-member session — the platform is fully private.
+- Two ingest endpoints additionally accept a CI bearer token so automation can
+  write without a browser session: `POST /api/platform/runs` and
+  `POST /api/platform/db-status` with
+  `Authorization: Bearer $PLATFORM_INGEST_TOKEN`.
+- The tracked repos and the per-repo allowlist of dispatchable workflow files
+  live in `content/platform.ts`. A workflow not allowlisted there cannot be
+  triggered from the UI, whoever asks.
+
+## Environment variables
+
+Local (`.env.local`) and on Vercel — see `.env.example`:
+
+```
+GH_PLATFORM_TOKEN=      # fine-grained PAT: actions:read (+ actions:write for dispatch)
+PLATFORM_INGEST_TOKEN=  # openssl rand -hex 32 — shared with CI + the droplet cron
+```
+
+Both are optional-but-recommended: without `GH_PLATFORM_TOKEN` the GitHub tabs
+use unauthenticated calls (60 req/h shared quota) and dispatch is disabled;
+without `PLATFORM_INGEST_TOKEN` token ingest is disabled (session-only writes).
+
+## Recording a model run from CI / a training script
+
+```sh
+curl -sS -X POST "$PROD_URL/api/platform/runs" \
+  -H "Authorization: Bearer $PLATFORM_INGEST_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @- << 'JSON'
+{
+  "model_id": "nfl_ep",
+  "sport": "nfl",
+  "run_name": "era-retrain 2026-07",
+  "status": "completed",
+  "params": { "eta": 0.025, "nrounds": 525 },
+  "metrics": { "ep_corr_vs_nflfastr": 0.996, "epa_corr": 0.994 },
+  "gates": [
+    { "name": "ep_corr_vs_nflfastr", "threshold": 0.99, "observed": 0.996,
+      "comparison": "gte", "passed": true }
+  ],
+  "artifacts": [
+    { "name": "ep_model.ubj",
+      "url": "https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nfl_model_artifacts" }
+  ],
+  "git": { "repo": "sportsdataverse/nfl-data", "branch": "main", "sha": "abc123" },
+  "tags": ["era-aware"]
+}
+JSON
+```
+
+Python (requests) equivalent — drop it at the end of a training script:
+
+```python
+import os, requests
+
+requests.post(
+    f"{os.environ['SDV_PLATFORM_URL']}/api/platform/runs",
+    headers={"Authorization": f"Bearer {os.environ['PLATFORM_INGEST_TOKEN']}"},
+    json={
+        "model_id": "cfb_wp",
+        "sport": "cfb",
+        "status": "completed",
+        "metrics": {"brier": 0.041},
+        "gates": [{"name": "brier_vs_market", "threshold": 0.05,
+                   "observed": 0.041, "comparison": "lte", "passed": True}],
+    },
+    timeout=30,
+).raise_for_status()
+```
+
+Validation is zod-side (`lib/platform/schemas.ts`): `model_id` is a lowercase
+slug, `metrics` values must be numbers, `gates[].comparison` is `gte`/`lte`,
+timestamps are ISO-8601 with offset.
+
+## Database heartbeat from the sdv-data droplet
+
+The site never dials Postgres — the droplet's DB ports stay closed to the
+public internet. A daily cron on the droplet pushes a snapshot instead
+(anything older than 26 h renders as **stale**):
+
+```sh
+#!/usr/bin/env bash
+# /opt/sdv-db/heartbeat.sh — cron: 15 6 * * *
+set -euo pipefail
+PSQL="psql -U postgres -d sdv -tA"
+curl -sS -X POST "$SDV_PLATFORM_URL/api/platform/db-status" \
+  -H "Authorization: Bearer $PLATFORM_INGEST_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n \
+    --arg version "$($PSQL -c 'show server_version')" \
+    --argjson size "$($PSQL -c "select pg_database_size('sdv')")" \
+    --argjson tables "$($PSQL -c "select count(*) from information_schema.tables where table_schema not in ('pg_catalog','information_schema')")" \
+    --argjson rows "$($PSQL -c "select coalesce(sum(n_live_tup),0) from pg_stat_user_tables")" \
+    '{source: "sdv-db", ok: true, host_label: "sdv-data droplet",
+      postgres_version: $version, db_size_bytes: $size,
+      table_count: $tables, row_estimate: $rows,
+      collected_at: (now | todate)}')"
+```
+
+Optionally add a `datasets: [{name, rows, last_updated}]` array (≤200 entries)
+for per-dataset freshness — the Database tab renders it as a table. On failure,
+POST `{"source": "sdv-db", "ok": false, "error": "...", "collected_at": ...}`
+so the outage is visible rather than silently stale.
+
+## GitHub PAT for the Automation/Datasets tabs
+
+Fine-grained PAT (org: sportsdataverse) with **Actions: read** — plus
+**Actions: write** if the dispatch buttons should work. Repository access:
+the repos listed in `content/platform.ts`. Set it as `GH_PLATFORM_TOKEN` on
+Vercel (server-side only; it is never sent to the browser).
+
+## Adding a repo / workflow / model
+
+- **Repo or workflow allowlist:** edit `content/platform.ts` (a PR — deliberate).
+- **Model:** nothing to register — the registry is an aggregation over
+  ingested runs; a new `model_id` appears on first POST.

--- a/frontend/components/platform/PlatformShell.tsx
+++ b/frontend/components/platform/PlatformShell.tsx
@@ -100,6 +100,7 @@ export default function PlatformShell({ session, title, children }: ShellProps) 
               <Link
                 key={tab.href}
                 href={tab.href}
+                aria-current={active ? "page" : undefined}
                 className={`-mb-px border-b-2 px-4 py-2 font-inter text-sm font-medium transition-colors ${
                   active
                     ? "border-primary text-primary"

--- a/frontend/components/platform/PlatformShell.tsx
+++ b/frontend/components/platform/PlatformShell.tsx
@@ -1,0 +1,189 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { signIn, signOut } from "next-auth/react";
+import { Github } from "lucide-react";
+import { Button } from "@components/ui/button";
+import type { PlatformSessionProps } from "@lib/platform/auth";
+
+/**
+ * Shared chrome for the members-only /platform area: handles the
+ * members-only gate (mirrors /packages/manage) and renders the tab nav +
+ * session bar around authorized content.
+ */
+
+export const PLATFORM_TABS = [
+  { href: "/platform", label: "Overview" },
+  { href: "/platform/automation", label: "Automation" },
+  { href: "/platform/datasets", label: "Datasets" },
+  { href: "/platform/models", label: "Models" },
+  { href: "/platform/database", label: "Database" },
+] as const;
+
+type ShellProps = {
+  session: PlatformSessionProps;
+  title: string;
+  children: React.ReactNode;
+};
+
+export default function PlatformShell({ session, title, children }: ShellProps) {
+  const router = useRouter();
+  const { authorized, signedIn, login } = session;
+
+  if (!authorized) {
+    return (
+      <>
+        <Head>
+          <title>{title} · SportsDataverse Platform</title>
+        </Head>
+        <div className="mx-auto flex min-h-[70vh] max-w-xl flex-col items-center justify-center gap-5 px-6 text-center">
+          <h1 className="bg-gradient-to-r from-primary via-accent to-primary bg-clip-text font-sarina text-3xl font-bold text-transparent">
+            SportsDataverse Platform
+          </h1>
+          {signedIn ? (
+            <p className="font-inter text-muted-foreground">
+              Your GitHub account isn&apos;t an active member of the{" "}
+              <span className="font-semibold">sportsdataverse</span> organization,
+              so the platform is off limits. If you believe this is a mistake, ask
+              an org admin to confirm your membership.
+            </p>
+          ) : (
+            <p className="font-inter text-muted-foreground">
+              The platform (automation, datasets, model runs, database status) is
+              available to members of the{" "}
+              <span className="font-semibold">sportsdataverse</span> GitHub
+              organization. Sign in to continue.
+            </p>
+          )}
+          <div className="flex gap-3">
+            {signedIn ? (
+              <Button variant="outline" onClick={() => signOut()}>
+                Sign out
+              </Button>
+            ) : (
+              <Button onClick={() => signIn("github", { callbackUrl: router.asPath })}>
+                <Github className="mr-2 h-4 w-4" /> Sign in with GitHub
+              </Button>
+            )}
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>{title} · SportsDataverse Platform</title>
+      </Head>
+      <div className="mx-auto max-w-6xl px-6 py-24">
+        <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
+          <h1 className="bg-gradient-to-r from-primary via-accent to-primary bg-clip-text font-sarina text-3xl font-bold text-transparent">
+            Platform
+          </h1>
+          <div className="flex items-center gap-3">
+            <span className="font-inter text-sm text-muted-foreground">
+              @{login}
+            </span>
+            <Button variant="ghost" size="sm" onClick={() => signOut()}>
+              Sign out
+            </Button>
+          </div>
+        </div>
+        <nav className="mb-8 flex flex-wrap gap-1 border-b border-gray-200 dark:border-gray-700">
+          {PLATFORM_TABS.map((tab) => {
+            const active =
+              tab.href === "/platform"
+                ? router.pathname === "/platform"
+                : router.pathname.startsWith(tab.href);
+            return (
+              <Link
+                key={tab.href}
+                href={tab.href}
+                className={`-mb-px border-b-2 px-4 py-2 font-inter text-sm font-medium transition-colors ${
+                  active
+                    ? "border-primary text-primary"
+                    : "border-transparent text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {tab.label}
+              </Link>
+            );
+          })}
+        </nav>
+        {children}
+      </div>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Small shared widgets
+// ---------------------------------------------------------------------------
+
+/** Colored chip for workflow conclusions / run statuses / booleans. */
+export function StatusBadge({ status }: { status: string | null | undefined }) {
+  const value = (status ?? "unknown").toLowerCase();
+  const tone =
+    value === "success" || value === "completed" || value === "ok" || value === "passed"
+      ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300"
+      : value === "in_progress" || value === "queued" || value === "running" || value === "stale"
+        ? "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300"
+        : value === "unknown" || value === "none"
+          ? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+          : "bg-red-100 text-red-700 dark:bg-red-950/40 dark:text-red-300";
+  return (
+    <span
+      className={`inline-block rounded-full px-2 py-0.5 text-xs font-semibold uppercase tracking-wide ${tone}`}
+    >
+      {value.replace(/_/g, " ")}
+    </span>
+  );
+}
+
+/** Inline SVG sparkline — avoids a charting dependency for trend-at-a-glance. */
+export function Sparkline({ values, width = 120, height = 28 }: {
+  values: number[];
+  width?: number;
+  height?: number;
+}) {
+  if (values.length < 2) {
+    return <span className="font-inter text-xs text-muted-foreground">–</span>;
+  }
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = max - min || 1;
+  const pad = 2;
+  const points = values
+    .map((v, i) => {
+      const x = pad + (i * (width - 2 * pad)) / (values.length - 1);
+      const y = height - pad - ((v - min) * (height - 2 * pad)) / span;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+  return (
+    <svg width={width} height={height} className="text-primary" aria-hidden="true">
+      <polyline points={points} fill="none" stroke="currentColor" strokeWidth="1.5" />
+    </svg>
+  );
+}
+
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.min(Math.floor(Math.log2(bytes) / 10), units.length - 1);
+  return `${(bytes / 2 ** (10 * i)).toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+export function timeAgo(iso: string | null | undefined): string {
+  if (!iso) return "never";
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return "unknown";
+  const seconds = Math.max(0, Math.floor((Date.now() - then) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}

--- a/frontend/content/platform.ts
+++ b/frontend/content/platform.ts
@@ -1,0 +1,77 @@
+/**
+ * Tracked repos for the members-only /platform area.
+ *
+ * Single source of truth for which org repos the automation + dataset
+ * dashboards cover. Editing this list is a deliberate, reviewable code change.
+ *
+ * `dispatchable` is an allowlist of workflow file names that may be triggered
+ * via workflow_dispatch from the UI — anything not listed here can only be
+ * observed, never dispatched.
+ */
+export type PlatformRepoKind = "raw" | "data" | "package";
+
+export type PlatformRepo = {
+  /** owner/name on GitHub */
+  repo: string;
+  kind: PlatformRepoKind;
+  sport: string;
+  /** Workflow file names (e.g. "scrape.yml") that may be dispatched from the UI. */
+  dispatchable?: string[];
+  /** Include this repo's GitHub releases on the Datasets page. */
+  hasReleases?: boolean;
+};
+
+export const SDV_ORG_SLUG = "sportsdataverse";
+
+export const PLATFORM_REPOS: PlatformRepo[] = [
+  { repo: "sportsdataverse/nfl-raw", kind: "raw", sport: "nfl" },
+  {
+    repo: "sportsdataverse/nfl-data",
+    kind: "data",
+    sport: "nfl",
+    hasReleases: true,
+    dispatchable: ["nfl_pbp_cron.yml", "nfl_rosters_players_cron.yml"],
+  },
+  {
+    repo: "sportsdataverse/cfbfastR-raw",
+    kind: "raw",
+    sport: "cfb",
+    dispatchable: ["cfbfastR_data_trigger.yaml"],
+  },
+  {
+    repo: "sportsdataverse/cfbfastR-data",
+    kind: "data",
+    sport: "cfb",
+    hasReleases: true,
+    dispatchable: ["daily_cfb.yml", "update_rosters.yml"],
+  },
+  {
+    repo: "sportsdataverse/hoopR-data",
+    kind: "data",
+    sport: "mbb/nba",
+    hasReleases: true,
+    dispatchable: ["scrape_mbb.yml", "scrape_nba.yml"],
+  },
+  { repo: "sportsdataverse/wehoop-data", kind: "data", sport: "wbb/wnba", hasReleases: true },
+  { repo: "sportsdataverse/fastRhockey-data", kind: "data", sport: "hockey", hasReleases: true },
+  {
+    repo: "sportsdataverse/baseballr-data",
+    kind: "data",
+    sport: "mlb",
+    hasReleases: true,
+    dispatchable: ["daily_ncaa_baseball.yml"],
+  },
+  { repo: "sportsdataverse/sportsdataverse-data", kind: "data", sport: "multi", hasReleases: true },
+  {
+    repo: "sportsdataverse/sportsdataverse-py",
+    kind: "package",
+    sport: "multi",
+    dispatchable: ["live-tests-cron.yml", "validation-cron.yml"],
+  },
+];
+
+/** True when `workflowFile` in `repo` is allowlisted for workflow_dispatch. */
+export function isDispatchAllowed(repo: string, workflowFile: string): boolean {
+  const entry = PLATFORM_REPOS.find((r) => r.repo === repo);
+  return Boolean(entry?.dispatchable?.includes(workflowFile));
+}

--- a/frontend/lib/platform/auth.ts
+++ b/frontend/lib/platform/auth.ts
@@ -1,0 +1,67 @@
+import { timingSafeEqual } from "crypto";
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { GetServerSidePropsContext } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@lib/auth";
+
+/**
+ * Auth helpers for the members-only /platform area.
+ *
+ * The whole platform (pages AND api routes, including GETs) is private to
+ * active sportsdataverse org members — unlike /api/packages where GET is
+ * public. The one exception is run ingest, which also accepts the CI bearer
+ * token (see `checkIngestToken`).
+ */
+
+export type PlatformSessionProps = {
+  authorized: boolean;
+  signedIn: boolean;
+  login: string | null;
+};
+
+/** Page-side gate: resolve session → props consumed by PlatformShell. */
+export async function getPlatformSessionProps(
+  ctx: GetServerSidePropsContext
+): Promise<PlatformSessionProps> {
+  const session = await getServerSession(ctx.req, ctx.res, authOptions);
+  return {
+    authorized: Boolean(session?.isOrgMember),
+    signedIn: Boolean(session),
+    login: session?.login ?? null,
+  };
+}
+
+/**
+ * API-side gate: returns the acting login, or responds 401 and returns null.
+ * Callers must `return` immediately when null.
+ */
+export async function requireMember(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<string | null> {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session?.isOrgMember) {
+    res.status(401).json({
+      message:
+        "Unauthorized: sign in with a sportsdataverse GitHub org account to use the platform.",
+      success: false,
+    });
+    return null;
+  }
+  return session.login ?? "unknown";
+}
+
+/**
+ * CI ingest auth: `Authorization: Bearer <PLATFORM_INGEST_TOKEN>`.
+ * Fails closed when the env var is unset. Timing-safe comparison.
+ */
+export function checkIngestToken(req: NextApiRequest): boolean {
+  const expected = process.env.PLATFORM_INGEST_TOKEN;
+  if (!expected) return false;
+  const header = req.headers.authorization;
+  if (!header?.startsWith("Bearer ")) return false;
+  const given = header.slice("Bearer ".length);
+  const a = Buffer.from(given);
+  const b = Buffer.from(expected);
+  return a.length === b.length && timingSafeEqual(a, b);
+}

--- a/frontend/lib/platform/dbStatus.ts
+++ b/frontend/lib/platform/dbStatus.ts
@@ -12,9 +12,11 @@ const COLLECTION = "db_status";
 
 export async function upsertDbStatus(status: DbStatusInput, actor: string): Promise<void> {
   const { db } = await connectToDatabase();
-  await db.collection(COLLECTION).updateOne(
+  // replaceOne (not $set) so optional fields absent from THIS heartbeat —
+  // e.g. a stale `error` after recovery — don't linger from the previous one.
+  await db.collection(COLLECTION).replaceOne(
     { source: status.source },
-    { $set: { ...status, reported_by: actor, received_at: new Date().toISOString() } },
+    { ...status, reported_by: actor, received_at: new Date().toISOString() },
     { upsert: true }
   );
 }

--- a/frontend/lib/platform/dbStatus.ts
+++ b/frontend/lib/platform/dbStatus.ts
@@ -1,0 +1,26 @@
+import { connectToDatabase } from "@lib/mongodb";
+import type { DbStatusDoc, DbStatusInput } from "./schemas";
+
+/**
+ * Latest-snapshot store for pushed database heartbeats (`db_status`
+ * collection, one doc per `source`, upserted). The sdv-data droplet cron is
+ * the writer; the platform UI is the reader. Staleness is judged client-side
+ * from `collected_at`.
+ */
+
+const COLLECTION = "db_status";
+
+export async function upsertDbStatus(status: DbStatusInput, actor: string): Promise<void> {
+  const { db } = await connectToDatabase();
+  await db.collection(COLLECTION).updateOne(
+    { source: status.source },
+    { $set: { ...status, reported_by: actor, received_at: new Date().toISOString() } },
+    { upsert: true }
+  );
+}
+
+export async function listDbStatuses(): Promise<DbStatusDoc[]> {
+  const { db } = await connectToDatabase();
+  const docs = await db.collection(COLLECTION).find({}).sort({ source: 1 }).toArray();
+  return docs.map((doc: any) => ({ ...doc, _id: String(doc._id) }));
+}

--- a/frontend/lib/platform/github.ts
+++ b/frontend/lib/platform/github.ts
@@ -1,0 +1,200 @@
+/**
+ * Server-only GitHub REST helpers for the /platform area.
+ *
+ * Auth: `GH_PLATFORM_TOKEN` (fine-grained PAT, actions:read + actions:write
+ * on the org repos). Read endpoints degrade to unauthenticated calls (public
+ * repos work, 60 req/h rate limit) when the token is unset; dispatch refuses.
+ *
+ * Never import this from client code — the token must not ship to browsers.
+ */
+
+const GH_API = "https://api.github.com";
+
+function ghHeaders(): HeadersInit {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "sportsdataverse-web-platform",
+  };
+  const token = process.env.GH_PLATFORM_TOKEN;
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
+export class GithubError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+async function ghGet<T>(path: string): Promise<T> {
+  const res = await fetch(`${GH_API}${path}`, { headers: ghHeaders() });
+  if (!res.ok) {
+    throw new GithubError(res.status, `GitHub ${path} -> ${res.status}`);
+  }
+  return (await res.json()) as T;
+}
+
+// ---------------------------------------------------------------------------
+// Workflows / runs (Automation pillar)
+// ---------------------------------------------------------------------------
+
+export type WorkflowRunSummary = {
+  id: number;
+  run_number: number;
+  event: string;
+  status: string | null; // queued | in_progress | completed
+  conclusion: string | null; // success | failure | cancelled | ...
+  html_url: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type WorkflowSummary = {
+  id: number;
+  name: string;
+  path: string; // ".github/workflows/<file>"
+  file: string; // "<file>"
+  state: string; // active | disabled_*
+  html_url: string;
+  latest_run: WorkflowRunSummary | null;
+};
+
+type GhWorkflow = {
+  id: number;
+  name: string;
+  path: string;
+  state: string;
+  html_url: string;
+};
+
+type GhRun = WorkflowRunSummary & { workflow_id: number };
+
+/**
+ * List a repo's workflows with each one's latest run. Two API calls per repo
+ * (workflows + last 50 runs), matched in memory — cheap enough for a
+ * dashboard, no pagination loops.
+ */
+export async function listRepoWorkflows(repo: string): Promise<WorkflowSummary[]> {
+  const [wfs, runs] = await Promise.all([
+    ghGet<{ workflows: GhWorkflow[] }>(`/repos/${repo}/actions/workflows?per_page=100`),
+    ghGet<{ workflow_runs: GhRun[] }>(`/repos/${repo}/actions/runs?per_page=50`),
+  ]);
+  const latestByWorkflow = new Map<number, GhRun>();
+  for (const run of runs.workflow_runs) {
+    // Runs come newest-first; keep the first seen per workflow.
+    if (!latestByWorkflow.has(run.workflow_id)) latestByWorkflow.set(run.workflow_id, run);
+  }
+  return wfs.workflows.map((wf) => {
+    const run = latestByWorkflow.get(wf.id) ?? null;
+    return {
+      id: wf.id,
+      name: wf.name,
+      path: wf.path,
+      file: wf.path.split("/").pop() ?? wf.path,
+      state: wf.state,
+      html_url: wf.html_url,
+      latest_run: run
+        ? {
+            id: run.id,
+            run_number: run.run_number,
+            event: run.event,
+            status: run.status,
+            conclusion: run.conclusion,
+            html_url: run.html_url,
+            created_at: run.created_at,
+            updated_at: run.updated_at,
+          }
+        : null,
+    };
+  });
+}
+
+/** Trigger workflow_dispatch on `ref` (default branch name). 204 on success. */
+export async function dispatchWorkflow(
+  repo: string,
+  workflowFile: string,
+  ref = "main"
+): Promise<void> {
+  if (!process.env.GH_PLATFORM_TOKEN) {
+    throw new GithubError(503, "GH_PLATFORM_TOKEN is not configured; dispatch is disabled.");
+  }
+  const res = await fetch(
+    `${GH_API}/repos/${repo}/actions/workflows/${encodeURIComponent(workflowFile)}/dispatches`,
+    {
+      method: "POST",
+      headers: { ...ghHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ ref }),
+    }
+  );
+  if (res.status !== 204) {
+    const body = await res.text();
+    throw new GithubError(res.status, `dispatch ${repo}/${workflowFile} -> ${res.status}: ${body.slice(0, 300)}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Releases (Datasets pillar)
+// ---------------------------------------------------------------------------
+
+export type ReleaseAssetSummary = {
+  name: string;
+  size: number;
+  download_count: number;
+  updated_at: string;
+  browser_download_url: string;
+};
+
+export type ReleaseSummary = {
+  tag: string;
+  name: string | null;
+  html_url: string;
+  published_at: string | null;
+  asset_count: number;
+  total_size: number;
+  assets: ReleaseAssetSummary[];
+};
+
+type GhRelease = {
+  tag_name: string;
+  name: string | null;
+  html_url: string;
+  published_at: string | null;
+  assets: {
+    name: string;
+    size: number;
+    download_count: number;
+    updated_at: string;
+    browser_download_url: string;
+  }[];
+};
+
+/**
+ * A repo's releases, newest first. Assets are truncated to the newest 20 per
+ * release to keep payloads sane (sportsdataverse-data releases carry hundreds
+ * of assets); `asset_count`/`total_size` always reflect the full set.
+ */
+export async function listRepoReleases(repo: string, perPage = 15): Promise<ReleaseSummary[]> {
+  const releases = await ghGet<GhRelease[]>(`/repos/${repo}/releases?per_page=${perPage}`);
+  return releases.map((rel) => ({
+    tag: rel.tag_name,
+    name: rel.name,
+    html_url: rel.html_url,
+    published_at: rel.published_at,
+    asset_count: rel.assets.length,
+    total_size: rel.assets.reduce((sum, a) => sum + a.size, 0),
+    assets: rel.assets
+      .slice()
+      .sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1))
+      .slice(0, 20)
+      .map((a) => ({
+        name: a.name,
+        size: a.size,
+        download_count: a.download_count,
+        updated_at: a.updated_at,
+        browser_download_url: a.browser_download_url,
+      })),
+  }));
+}

--- a/frontend/lib/platform/github.ts
+++ b/frontend/lib/platform/github.ts
@@ -29,8 +29,14 @@ export class GithubError extends Error {
   }
 }
 
+/** Hard cap on any single GitHub call so a slow upstream can't hang a page render. */
+const GH_TIMEOUT_MS = 15_000;
+
 async function ghGet<T>(path: string): Promise<T> {
-  const res = await fetch(`${GH_API}${path}`, { headers: ghHeaders() });
+  const res = await fetch(`${GH_API}${path}`, {
+    headers: ghHeaders(),
+    signal: AbortSignal.timeout(GH_TIMEOUT_MS),
+  });
   if (!res.ok) {
     throw new GithubError(res.status, `GitHub ${path} -> ${res.status}`);
   }
@@ -127,6 +133,7 @@ export async function dispatchWorkflow(
       method: "POST",
       headers: { ...ghHeaders(), "Content-Type": "application/json" },
       body: JSON.stringify({ ref }),
+      signal: AbortSignal.timeout(GH_TIMEOUT_MS),
     }
   );
   if (res.status !== 204) {

--- a/frontend/lib/platform/runs.ts
+++ b/frontend/lib/platform/runs.ts
@@ -1,0 +1,98 @@
+import { ObjectId } from "mongodb";
+import { connectToDatabase } from "@lib/mongodb";
+import type { ModelRunDoc, ModelRunInput, ModelSummary } from "./schemas";
+
+/**
+ * MongoDB store for model runs (`model_runs` collection). Shared by the API
+ * routes and getServerSideProps so pages can read without an internal HTTP
+ * round trip. All returns are JSON-serializable (ObjectId → string).
+ */
+
+const COLLECTION = "model_runs";
+
+function serialize(doc: any): ModelRunDoc {
+  return { ...doc, _id: String(doc._id) };
+}
+
+export type RunFilters = {
+  model_id?: string;
+  sport?: string;
+  status?: string;
+  limit?: number;
+};
+
+export async function listRuns(filters: RunFilters = {}): Promise<ModelRunDoc[]> {
+  const { db } = await connectToDatabase();
+  const query: Record<string, unknown> = {};
+  if (filters.model_id) query.model_id = filters.model_id;
+  if (filters.sport) query.sport = filters.sport;
+  if (filters.status) query.status = filters.status;
+  const limit = Math.min(Math.max(filters.limit ?? 100, 1), 500);
+  const docs = await db
+    .collection(COLLECTION)
+    .find(query)
+    .sort({ created_at: -1 })
+    .limit(limit)
+    .toArray();
+  return docs.map(serialize);
+}
+
+export async function getRun(id: string): Promise<ModelRunDoc | null> {
+  if (!ObjectId.isValid(id)) return null;
+  const { db } = await connectToDatabase();
+  const doc = await db.collection(COLLECTION).findOne({ _id: new ObjectId(id) });
+  return doc ? serialize(doc) : null;
+}
+
+export async function insertRun(run: ModelRunInput, actor: string): Promise<string> {
+  const { db } = await connectToDatabase();
+  const now = new Date().toISOString();
+  const result = await db.collection(COLLECTION).insertOne({
+    ...run,
+    created_by: actor,
+    created_at: now,
+    updated_at: now,
+  });
+  return String(result.insertedId);
+}
+
+export async function deleteRun(id: string): Promise<boolean> {
+  if (!ObjectId.isValid(id)) return false;
+  const { db } = await connectToDatabase();
+  const result = await db.collection(COLLECTION).deleteOne({ _id: new ObjectId(id) });
+  return result.deletedCount === 1;
+}
+
+/** Registry: one row per model_id, newest-run first. */
+export async function listModels(): Promise<ModelSummary[]> {
+  const { db } = await connectToDatabase();
+  const rows = await db
+    .collection(COLLECTION)
+    .aggregate([
+      { $sort: { created_at: -1 } },
+      {
+        $group: {
+          _id: "$model_id",
+          sport: { $first: "$sport" },
+          run_count: { $sum: 1 },
+          latest_run_at: { $first: "$created_at" },
+          latest_status: { $first: "$status" },
+          latest_gates: { $first: "$gates" },
+        },
+      },
+      { $sort: { latest_run_at: -1 } },
+    ])
+    .toArray();
+  return rows.map((row: any) => {
+    const gates: { passed?: boolean }[] = Array.isArray(row.latest_gates) ? row.latest_gates : [];
+    return {
+      model_id: String(row._id),
+      sport: row.sport ?? "unknown",
+      run_count: row.run_count ?? 0,
+      latest_run_at: row.latest_run_at ?? "",
+      latest_status: row.latest_status ?? "completed",
+      gates_total: gates.length,
+      gates_passed: gates.filter((g) => g.passed === true).length,
+    };
+  });
+}

--- a/frontend/lib/platform/schemas.ts
+++ b/frontend/lib/platform/schemas.ts
@@ -78,7 +78,10 @@ export const dbStatusSchema = z.object({
       z.object({
         name: z.string().max(120),
         rows: z.number().nonnegative().optional(),
+        /** When the dataset last gained rows (max of its event/load timestamp). */
         last_updated: z.string().datetime({ offset: true }).optional(),
+        /** Human-readable identity of the newest row, e.g. "game_id=401628 (2026-01-13)". */
+        latest_row: z.string().max(300).optional(),
       })
     )
     .max(200)

--- a/frontend/lib/platform/schemas.ts
+++ b/frontend/lib/platform/schemas.ts
@@ -1,0 +1,106 @@
+import { z } from "zod";
+
+/**
+ * Model-run tracking schemas (MongoDB `model_runs` collection).
+ *
+ * Runs are ingested either by a signed-in org member or by CI via the
+ * `PLATFORM_INGEST_TOKEN` bearer token (see lib/platform/auth.ts). The server
+ * stamps `created_by/created_at/updated_at`; client `_id` is ignored.
+ */
+
+const SLUG = /^[a-z0-9][a-z0-9_-]*$/;
+
+/** An oracle gate — the org's evaluation currency (threshold vs observed). */
+export const gateSchema = z.object({
+  name: z.string().min(1).max(120),
+  threshold: z.number(),
+  observed: z.number(),
+  comparison: z.enum(["gte", "lte"]).default("gte"),
+  passed: z.boolean(),
+});
+
+export const artifactSchema = z.object({
+  name: z.string().min(1).max(200),
+  url: z.string().url().max(2000),
+});
+
+export const runStatusValues = ["running", "completed", "failed"] as const;
+
+export const modelRunSchema = z.object({
+  model_id: z.string().regex(SLUG, "lowercase slug (a-z0-9_-)").max(80),
+  sport: z.string().min(1).max(20),
+  run_name: z.string().max(200).optional(),
+  status: z.enum(runStatusValues).default("completed"),
+  params: z.record(z.union([z.string(), z.number(), z.boolean()])).default({}),
+  metrics: z.record(z.number()).default({}),
+  gates: z.array(gateSchema).default([]),
+  artifacts: z.array(artifactSchema).default([]),
+  git: z
+    .object({
+      repo: z.string().max(200).optional(),
+      branch: z.string().max(200).optional(),
+      sha: z.string().max(64).optional(),
+    })
+    .optional(),
+  tags: z.array(z.string().max(60)).default([]),
+  notes: z.string().max(5000).optional(),
+  started_at: z.string().datetime({ offset: true }).optional(),
+  finished_at: z.string().datetime({ offset: true }).optional(),
+});
+
+export type Gate = z.infer<typeof gateSchema>;
+export type ModelRunInput = z.infer<typeof modelRunSchema>;
+
+/** A run as stored/returned (server-stamped metadata included). */
+export type ModelRunDoc = ModelRunInput & {
+  _id: string;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+};
+
+/**
+ * sdv-data droplet Postgres heartbeat (Mongo `db_status` collection, one doc
+ * per `source`). The droplet cron PUSHES this — the site never dials the DB
+ * (its ports are closed to the public internet by design).
+ */
+export const dbStatusSchema = z.object({
+  source: z.string().regex(SLUG).max(60).default("sdv-db"),
+  ok: z.boolean(),
+  host_label: z.string().max(120).optional(),
+  postgres_version: z.string().max(200).optional(),
+  db_size_bytes: z.number().nonnegative().optional(),
+  table_count: z.number().int().nonnegative().optional(),
+  row_estimate: z.number().nonnegative().optional(),
+  /** Per-dataset freshness, capped so a heartbeat stays small. */
+  datasets: z
+    .array(
+      z.object({
+        name: z.string().max(120),
+        rows: z.number().nonnegative().optional(),
+        last_updated: z.string().datetime({ offset: true }).optional(),
+      })
+    )
+    .max(200)
+    .default([]),
+  error: z.string().max(2000).optional(),
+  collected_at: z.string().datetime({ offset: true }),
+});
+
+export type DbStatusInput = z.infer<typeof dbStatusSchema>;
+export type DbStatusDoc = DbStatusInput & {
+  _id: string;
+  reported_by: string;
+  received_at: string;
+};
+
+/** Registry aggregation row: one line per model_id. */
+export type ModelSummary = {
+  model_id: string;
+  sport: string;
+  run_count: number;
+  latest_run_at: string;
+  latest_status: (typeof runStatusValues)[number];
+  gates_total: number;
+  gates_passed: number;
+};

--- a/frontend/pages/api/platform/automation.ts
+++ b/frontend/pages/api/platform/automation.ts
@@ -1,0 +1,83 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { PLATFORM_REPOS, isDispatchAllowed } from "@content/platform";
+import { requireMember } from "@lib/platform/auth";
+import { GithubError, dispatchWorkflow, listRepoWorkflows } from "@lib/platform/github";
+import type { WorkflowSummary } from "@lib/platform/github";
+
+export type AutomationRepo = {
+  repo: string;
+  kind: string;
+  sport: string;
+  dispatchable: string[];
+  workflows: WorkflowSummary[];
+  error: string | null;
+};
+
+/**
+ * GET  -> workflow + latest-run summary for every tracked repo.
+ * POST -> { repo, workflow, ref? } workflow_dispatch (allowlisted files only).
+ * Both require an org-member session; the GitHub token stays server-side.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const actor = await requireMember(req, res);
+  if (!actor) return;
+
+  if (req.method === "GET") {
+    // One failing repo must not blank the dashboard -> allSettled per repo.
+    const settled = await Promise.allSettled(
+      PLATFORM_REPOS.map((entry) => listRepoWorkflows(entry.repo))
+    );
+    const repos: AutomationRepo[] = PLATFORM_REPOS.map((entry, i) => {
+      const outcome = settled[i];
+      return {
+        repo: entry.repo,
+        kind: entry.kind,
+        sport: entry.sport,
+        dispatchable: entry.dispatchable ?? [],
+        workflows: outcome.status === "fulfilled" ? outcome.value : [],
+        error:
+          outcome.status === "rejected"
+            ? outcome.reason instanceof Error
+              ? outcome.reason.message
+              : String(outcome.reason)
+            : null,
+      };
+    });
+    return res.json({ message: repos, success: true });
+  }
+
+  if (req.method === "POST") {
+    const { repo, workflow, ref } = (req.body ?? {}) as {
+      repo?: string;
+      workflow?: string;
+      ref?: string;
+    };
+    if (typeof repo !== "string" || typeof workflow !== "string") {
+      return res
+        .status(400)
+        .json({ message: "Body must include { repo, workflow }.", success: false });
+    }
+    if (!isDispatchAllowed(repo, workflow)) {
+      return res.status(403).json({
+        message: `Workflow "${workflow}" in ${repo} is not allowlisted for dispatch (see content/platform.ts).`,
+        success: false,
+      });
+    }
+    try {
+      await dispatchWorkflow(repo, workflow, typeof ref === "string" && ref ? ref : "main");
+      return res.json({
+        message: `Dispatched ${workflow} on ${repo} (by @${actor}).`,
+        success: true,
+      });
+    } catch (error) {
+      const status = error instanceof GithubError ? error.status : 502;
+      return res.status(status >= 400 && status < 600 ? status : 502).json({
+        message: error instanceof Error ? error.message : "Dispatch failed",
+        success: false,
+      });
+    }
+  }
+
+  res.setHeader("Allow", "GET, POST");
+  return res.status(405).json({ message: "Method not allowed", success: false });
+}

--- a/frontend/pages/api/platform/db-status.ts
+++ b/frontend/pages/api/platform/db-status.ts
@@ -1,0 +1,68 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@lib/auth";
+import { checkIngestToken, requireMember } from "@lib/platform/auth";
+import { listDbStatuses, upsertDbStatus } from "@lib/platform/dbStatus";
+import { dbStatusSchema } from "@lib/platform/schemas";
+
+/**
+ * sdv-data droplet Postgres heartbeat.
+ *
+ * GET  -> latest snapshot per source (org member).
+ * POST -> upsert a snapshot (CI bearer token or org member). The droplet
+ *         PUSHES status on a cron — the site never dials the database (its
+ *         ports are closed to the public internet by design).
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === "GET") {
+    const actor = await requireMember(req, res);
+    if (!actor) return;
+    try {
+      const statuses = await listDbStatuses();
+      return res.json({ message: statuses, success: true });
+    } catch (error) {
+      return res.status(500).json({
+        message: error instanceof Error ? error.message : "Query failed",
+        success: false,
+      });
+    }
+  }
+
+  if (req.method === "POST") {
+    let actor: string | null = null;
+    if (checkIngestToken(req)) {
+      actor = "ci";
+    } else {
+      const session = await getServerSession(req, res, authOptions);
+      if (session?.isOrgMember) actor = session.login ?? "unknown";
+    }
+    if (!actor) {
+      return res.status(401).json({
+        message:
+          "Unauthorized: provide the platform ingest bearer token or sign in as a sportsdataverse org member.",
+        success: false,
+      });
+    }
+
+    const parsed = dbStatusSchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return res.status(400).json({
+        message: "Validation failed",
+        errors: parsed.error.flatten(),
+        success: false,
+      });
+    }
+    try {
+      await upsertDbStatus(parsed.data, actor);
+      return res.json({ message: "Status recorded", success: true });
+    } catch (error) {
+      return res.status(500).json({
+        message: error instanceof Error ? error.message : "Upsert failed",
+        success: false,
+      });
+    }
+  }
+
+  res.setHeader("Allow", "GET, POST");
+  return res.status(405).json({ message: "Method not allowed", success: false });
+}

--- a/frontend/pages/api/platform/runs.ts
+++ b/frontend/pages/api/platform/runs.ts
@@ -1,0 +1,72 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@lib/auth";
+import { checkIngestToken, requireMember } from "@lib/platform/auth";
+import { insertRun, listRuns } from "@lib/platform/runs";
+import { modelRunSchema } from "@lib/platform/schemas";
+
+/**
+ * GET  -> run list, filters: ?model_id=&sport=&status=&limit= (org member).
+ * POST -> ingest one run (org member session OR CI bearer token
+ *         `Authorization: Bearer <PLATFORM_INGEST_TOKEN>`).
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === "GET") {
+    const actor = await requireMember(req, res);
+    if (!actor) return;
+    const { model_id, sport, status, limit } = req.query;
+    try {
+      const runs = await listRuns({
+        model_id: typeof model_id === "string" ? model_id : undefined,
+        sport: typeof sport === "string" ? sport : undefined,
+        status: typeof status === "string" ? status : undefined,
+        limit: typeof limit === "string" ? Number(limit) || undefined : undefined,
+      });
+      return res.json({ message: runs, success: true });
+    } catch (error) {
+      return res.status(500).json({
+        message: error instanceof Error ? error.message : "Query failed",
+        success: false,
+      });
+    }
+  }
+
+  if (req.method === "POST") {
+    // CI token first (no session round trip); fall back to member session.
+    let actor: string | null = null;
+    if (checkIngestToken(req)) {
+      actor = "ci";
+    } else {
+      const session = await getServerSession(req, res, authOptions);
+      if (session?.isOrgMember) actor = session.login ?? "unknown";
+    }
+    if (!actor) {
+      return res.status(401).json({
+        message:
+          "Unauthorized: provide the platform ingest bearer token or sign in as a sportsdataverse org member.",
+        success: false,
+      });
+    }
+
+    const parsed = modelRunSchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return res.status(400).json({
+        message: "Validation failed",
+        errors: parsed.error.flatten(),
+        success: false,
+      });
+    }
+    try {
+      const id = await insertRun(parsed.data, actor);
+      return res.status(201).json({ message: "Run recorded", id, success: true });
+    } catch (error) {
+      return res.status(500).json({
+        message: error instanceof Error ? error.message : "Insert failed",
+        success: false,
+      });
+    }
+  }
+
+  res.setHeader("Allow", "GET, POST");
+  return res.status(405).json({ message: "Method not allowed", success: false });
+}

--- a/frontend/pages/api/platform/runs/[id].ts
+++ b/frontend/pages/api/platform/runs/[id].ts
@@ -9,16 +9,23 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   const id = typeof req.query.id === "string" ? req.query.id : "";
 
-  if (req.method === "GET") {
-    const run = await getRun(id);
-    if (!run) return res.status(404).json({ message: "Run not found", success: false });
-    return res.json({ message: run, success: true });
-  }
+  try {
+    if (req.method === "GET") {
+      const run = await getRun(id);
+      if (!run) return res.status(404).json({ message: "Run not found", success: false });
+      return res.json({ message: run, success: true });
+    }
 
-  if (req.method === "DELETE") {
-    const deleted = await deleteRun(id);
-    if (!deleted) return res.status(404).json({ message: "Run not found", success: false });
-    return res.json({ message: "Run deleted", success: true });
+    if (req.method === "DELETE") {
+      const deleted = await deleteRun(id);
+      if (!deleted) return res.status(404).json({ message: "Run not found", success: false });
+      return res.json({ message: "Run deleted", success: true });
+    }
+  } catch (error) {
+    return res.status(500).json({
+      message: error instanceof Error ? error.message : "Database error",
+      success: false,
+    });
   }
 
   res.setHeader("Allow", "GET, DELETE");

--- a/frontend/pages/api/platform/runs/[id].ts
+++ b/frontend/pages/api/platform/runs/[id].ts
@@ -1,0 +1,26 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { requireMember } from "@lib/platform/auth";
+import { deleteRun, getRun } from "@lib/platform/runs";
+
+/** GET one run | DELETE one run (both org-member only). */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const actor = await requireMember(req, res);
+  if (!actor) return;
+
+  const id = typeof req.query.id === "string" ? req.query.id : "";
+
+  if (req.method === "GET") {
+    const run = await getRun(id);
+    if (!run) return res.status(404).json({ message: "Run not found", success: false });
+    return res.json({ message: run, success: true });
+  }
+
+  if (req.method === "DELETE") {
+    const deleted = await deleteRun(id);
+    if (!deleted) return res.status(404).json({ message: "Run not found", success: false });
+    return res.json({ message: "Run deleted", success: true });
+  }
+
+  res.setHeader("Allow", "GET, DELETE");
+  return res.status(405).json({ message: "Method not allowed", success: false });
+}

--- a/frontend/pages/platform/automation.tsx
+++ b/frontend/pages/platform/automation.tsx
@@ -1,0 +1,168 @@
+import { useState } from "react";
+import type { GetServerSidePropsContext } from "next";
+import useSWR from "swr";
+import { ExternalLink, Play, RefreshCw } from "lucide-react";
+import PlatformShell, { StatusBadge, timeAgo } from "@components/platform/PlatformShell";
+import { Button } from "@components/ui/button";
+import type { PlatformSessionProps } from "@lib/platform/auth";
+import { getPlatformSessionProps } from "@lib/platform/auth";
+import type { AutomationRepo } from "../api/platform/automation";
+
+const fetcher = async (url: string) => {
+  const res = await fetch(url);
+  const data = await res.json();
+  if (!res.ok || !data.success) throw new Error(data.message || "Request failed");
+  return data.message as AutomationRepo[];
+};
+
+export default function PlatformAutomation({ session }: { session: PlatformSessionProps }) {
+  const { data, error, isLoading, mutate, isValidating } = useSWR(
+    session.authorized ? "/api/platform/automation" : null,
+    fetcher,
+    { refreshInterval: 60_000, revalidateOnFocus: false }
+  );
+  const [dispatching, setDispatching] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  async function dispatch(repo: string, workflow: string) {
+    if (!window.confirm(`Trigger ${workflow} on ${repo}?`)) return;
+    const key = `${repo}/${workflow}`;
+    setDispatching(key);
+    setNotice(null);
+    try {
+      const res = await fetch("/api/platform/automation", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ repo, workflow }),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.success) throw new Error(data.message || "Dispatch failed");
+      setNotice(data.message);
+      // Give GitHub a beat to register the queued run, then refresh.
+      setTimeout(() => mutate(), 3000);
+    } catch (e) {
+      setNotice(e instanceof Error ? e.message : "Dispatch failed");
+    } finally {
+      setDispatching(null);
+    }
+  }
+
+  return (
+    <PlatformShell session={session} title="Automation">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <p className="font-inter text-sm text-muted-foreground">
+          Workflow status across the tracked org repos — refreshes every minute.
+        </p>
+        <Button variant="outline" size="sm" onClick={() => mutate()} disabled={isValidating}>
+          <RefreshCw className={`mr-2 h-4 w-4 ${isValidating ? "animate-spin" : ""}`} />
+          Refresh
+        </Button>
+      </div>
+
+      {notice ? (
+        <div className="mb-4 rounded-md border border-sky-300 bg-sky-50 px-4 py-3 font-inter text-sm text-sky-800 dark:border-sky-800 dark:bg-sky-950/40 dark:text-sky-200">
+          {notice}
+        </div>
+      ) : null}
+      {error ? (
+        <div className="mb-4 rounded-md border border-red-300 bg-red-50 px-4 py-3 font-inter text-sm text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300">
+          {error.message}
+        </div>
+      ) : null}
+      {isLoading ? (
+        <p className="font-inter text-sm text-muted-foreground">Loading workflows…</p>
+      ) : null}
+
+      <div className="space-y-6">
+        {(data ?? []).map((repo) => (
+          <section key={repo.repo}>
+            <div className="mb-2 flex flex-wrap items-center gap-2">
+              <a
+                href={`https://github.com/${repo.repo}/actions`}
+                target="_blank"
+                rel="noreferrer"
+                className="font-barlow text-lg font-semibold hover:text-primary"
+              >
+                {repo.repo}
+              </a>
+              <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-primary dark:bg-white/10 dark:text-sky-300">
+                {repo.sport} · {repo.kind}
+              </span>
+            </div>
+            {repo.error ? (
+              <p className="font-inter text-sm text-red-600 dark:text-red-400">
+                Failed to load: {repo.error}
+              </p>
+            ) : repo.workflows.length === 0 ? (
+              <p className="font-inter text-sm text-muted-foreground">No workflows.</p>
+            ) : (
+              <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+                <table className="w-full text-left font-inter text-sm">
+                  <thead className="bg-gray-50 text-xs uppercase text-muted-foreground dark:bg-gray-800/60">
+                    <tr>
+                      <th className="px-4 py-2">Workflow</th>
+                      <th className="px-4 py-2">Last run</th>
+                      <th className="px-4 py-2">Trigger</th>
+                      <th className="px-4 py-2">When</th>
+                      <th className="px-4 py-2 text-right">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {repo.workflows.map((wf) => {
+                      const run = wf.latest_run;
+                      const key = `${repo.repo}/${wf.file}`;
+                      const canDispatch = repo.dispatchable.includes(wf.file);
+                      return (
+                        <tr key={wf.id} className="border-t border-gray-200 dark:border-gray-700">
+                          <td className="px-4 py-2 font-medium">{wf.name}</td>
+                          <td className="px-4 py-2">
+                            {run ? (
+                              <a
+                                href={run.html_url}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="inline-flex items-center gap-1 hover:text-primary"
+                              >
+                                <StatusBadge
+                                  status={run.status === "completed" ? run.conclusion : run.status}
+                                />
+                                <ExternalLink className="h-3 w-3" />
+                              </a>
+                            ) : (
+                              <StatusBadge status="none" />
+                            )}
+                          </td>
+                          <td className="px-4 py-2 text-muted-foreground">{run?.event ?? "–"}</td>
+                          <td className="px-4 py-2 text-muted-foreground">
+                            {timeAgo(run?.updated_at)}
+                          </td>
+                          <td className="px-4 py-2 text-right">
+                            {canDispatch ? (
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                disabled={dispatching === key}
+                                onClick={() => dispatch(repo.repo, wf.file)}
+                              >
+                                <Play className="mr-1 h-3 w-3" />
+                                {dispatching === key ? "Dispatching…" : "Run"}
+                              </Button>
+                            ) : null}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        ))}
+      </div>
+    </PlatformShell>
+  );
+}
+
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
+  return { props: { session: await getPlatformSessionProps(ctx) } };
+}

--- a/frontend/pages/platform/automation.tsx
+++ b/frontend/pages/platform/automation.tsx
@@ -22,7 +22,7 @@ export default function PlatformAutomation({ session }: { session: PlatformSessi
     { refreshInterval: 60_000, revalidateOnFocus: false }
   );
   const [dispatching, setDispatching] = useState<string | null>(null);
-  const [notice, setNotice] = useState<string | null>(null);
+  const [notice, setNotice] = useState<{ kind: "ok" | "error"; text: string } | null>(null);
 
   async function dispatch(repo: string, workflow: string) {
     if (!window.confirm(`Trigger ${workflow} on ${repo}?`)) return;
@@ -37,11 +37,11 @@ export default function PlatformAutomation({ session }: { session: PlatformSessi
       });
       const data = await res.json();
       if (!res.ok || !data.success) throw new Error(data.message || "Dispatch failed");
-      setNotice(data.message);
+      setNotice({ kind: "ok", text: data.message });
       // Give GitHub a beat to register the queued run, then refresh.
       setTimeout(() => mutate(), 3000);
     } catch (e) {
-      setNotice(e instanceof Error ? e.message : "Dispatch failed");
+      setNotice({ kind: "error", text: e instanceof Error ? e.message : "Dispatch failed" });
     } finally {
       setDispatching(null);
     }
@@ -60,8 +60,14 @@ export default function PlatformAutomation({ session }: { session: PlatformSessi
       </div>
 
       {notice ? (
-        <div className="mb-4 rounded-md border border-sky-300 bg-sky-50 px-4 py-3 font-inter text-sm text-sky-800 dark:border-sky-800 dark:bg-sky-950/40 dark:text-sky-200">
-          {notice}
+        <div
+          className={`mb-4 rounded-md border px-4 py-3 font-inter text-sm ${
+            notice.kind === "ok"
+              ? "border-sky-300 bg-sky-50 text-sky-800 dark:border-sky-800 dark:bg-sky-950/40 dark:text-sky-200"
+              : "border-red-300 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300"
+          }`}
+        >
+          {notice.text}
         </div>
       ) : null}
       {error ? (

--- a/frontend/pages/platform/database.tsx
+++ b/frontend/pages/platform/database.tsx
@@ -92,6 +92,7 @@ export default function PlatformDatabase({ session, statuses }: DatabaseProps) {
                         <th className="px-4 py-2">Dataset</th>
                         <th className="px-4 py-2">Rows</th>
                         <th className="px-4 py-2">Last updated</th>
+                        <th className="px-4 py-2">Latest row</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -106,6 +107,12 @@ export default function PlatformDatabase({ session, statuses }: DatabaseProps) {
                           </td>
                           <td className="px-4 py-2 text-muted-foreground">
                             {timeAgo(dataset.last_updated)}
+                          </td>
+                          <td
+                            className="max-w-[16rem] truncate px-4 py-2 font-mono text-xs text-muted-foreground"
+                            title={dataset.latest_row ?? undefined}
+                          >
+                            {dataset.latest_row ?? "–"}
                           </td>
                         </tr>
                       ))}

--- a/frontend/pages/platform/database.tsx
+++ b/frontend/pages/platform/database.tsx
@@ -1,0 +1,131 @@
+import type { GetServerSidePropsContext } from "next";
+import PlatformShell, { StatusBadge, formatBytes, timeAgo } from "@components/platform/PlatformShell";
+import type { PlatformSessionProps } from "@lib/platform/auth";
+import { getPlatformSessionProps } from "@lib/platform/auth";
+import { listDbStatuses } from "@lib/platform/dbStatus";
+import type { DbStatusDoc } from "@lib/platform/schemas";
+
+type DatabaseProps = {
+  session: PlatformSessionProps;
+  statuses: DbStatusDoc[];
+};
+
+/** A heartbeat older than this is flagged stale (droplet cron is daily). */
+const STALE_AFTER_MS = 26 * 60 * 60 * 1000;
+
+function statusOf(status: DbStatusDoc): string {
+  if (!status.ok) return "failed";
+  const age = Date.now() - Date.parse(status.collected_at);
+  return Number.isNaN(age) || age > STALE_AFTER_MS ? "stale" : "ok";
+}
+
+export default function PlatformDatabase({ session, statuses }: DatabaseProps) {
+  return (
+    <PlatformShell session={session} title="Database">
+      <p className="mb-6 font-inter text-sm text-muted-foreground">
+        Postgres warehouse heartbeats, pushed by the sdv-data droplet cron. The site
+        never dials the database — its ports stay closed to the public internet.
+      </p>
+      {statuses.length === 0 ? (
+        <p className="font-inter text-sm text-muted-foreground">
+          No heartbeats received yet. Wire the droplet cron to POST{" "}
+          <code>/api/platform/db-status</code> — recipe in SETUP-platform.md.
+        </p>
+      ) : (
+        <div className="space-y-8">
+          {statuses.map((status) => (
+            <section
+              key={status.source}
+              className="rounded-lg border border-gray-200 bg-white/70 p-5 dark:border-gray-700 dark:bg-darkSecondary/70"
+            >
+              <div className="mb-4 flex flex-wrap items-center gap-3">
+                <h2 className="font-barlow text-xl font-semibold">
+                  {status.host_label ?? status.source}
+                </h2>
+                <StatusBadge status={statusOf(status)} />
+                <span className="font-inter text-xs text-muted-foreground">
+                  heartbeat {timeAgo(status.collected_at)} · received {timeAgo(status.received_at)}
+                </span>
+              </div>
+
+              {status.error ? (
+                <div className="mb-4 rounded-md border border-red-300 bg-red-50 px-4 py-3 font-inter text-sm text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300">
+                  {status.error}
+                </div>
+              ) : null}
+
+              <div className="mb-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                {[
+                  { label: "Postgres", value: status.postgres_version ?? "–" },
+                  {
+                    label: "Size",
+                    value: status.db_size_bytes != null ? formatBytes(status.db_size_bytes) : "–",
+                  },
+                  {
+                    label: "Tables",
+                    value: status.table_count != null ? String(status.table_count) : "–",
+                  },
+                  {
+                    label: "Rows (est.)",
+                    value:
+                      status.row_estimate != null
+                        ? status.row_estimate.toLocaleString("en-US")
+                        : "–",
+                  },
+                ].map((stat) => (
+                  <div key={stat.label}>
+                    <div className="font-inter text-xs uppercase text-muted-foreground">
+                      {stat.label}
+                    </div>
+                    <div className="truncate font-barlow text-lg font-semibold" title={stat.value}>
+                      {stat.value}
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {status.datasets.length > 0 ? (
+                <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+                  <table className="w-full text-left font-inter text-sm">
+                    <thead className="bg-gray-50 text-xs uppercase text-muted-foreground dark:bg-gray-800/60">
+                      <tr>
+                        <th className="px-4 py-2">Dataset</th>
+                        <th className="px-4 py-2">Rows</th>
+                        <th className="px-4 py-2">Last updated</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {status.datasets.map((dataset) => (
+                        <tr
+                          key={dataset.name}
+                          className="border-t border-gray-200 dark:border-gray-700"
+                        >
+                          <td className="px-4 py-2 font-medium">{dataset.name}</td>
+                          <td className="px-4 py-2">
+                            {dataset.rows != null ? dataset.rows.toLocaleString("en-US") : "–"}
+                          </td>
+                          <td className="px-4 py-2 text-muted-foreground">
+                            {timeAgo(dataset.last_updated)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : null}
+            </section>
+          ))}
+        </div>
+      )}
+    </PlatformShell>
+  );
+}
+
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
+  const session = await getPlatformSessionProps(ctx);
+  if (!session.authorized) {
+    return { props: { session, statuses: [] } };
+  }
+  const statuses = await listDbStatuses().catch(() => []);
+  return { props: { session, statuses } };
+}

--- a/frontend/pages/platform/datasets.tsx
+++ b/frontend/pages/platform/datasets.tsx
@@ -1,0 +1,120 @@
+import type { GetServerSidePropsContext } from "next";
+import PlatformShell, { formatBytes, timeAgo } from "@components/platform/PlatformShell";
+import { PLATFORM_REPOS } from "@content/platform";
+import type { PlatformSessionProps } from "@lib/platform/auth";
+import { getPlatformSessionProps } from "@lib/platform/auth";
+import { listRepoReleases } from "@lib/platform/github";
+import type { ReleaseSummary } from "@lib/platform/github";
+
+type RepoReleases = {
+  repo: string;
+  sport: string;
+  releases: ReleaseSummary[];
+  error: string | null;
+};
+
+type DatasetsProps = {
+  session: PlatformSessionProps;
+  repos: RepoReleases[];
+};
+
+export default function PlatformDatasets({ session, repos }: DatasetsProps) {
+  return (
+    <PlatformShell session={session} title="Datasets">
+      <p className="mb-6 font-inter text-sm text-muted-foreground">
+        Release artifacts across the org&apos;s data repos — the distribution surface the
+        loaders (<code>load_*</code>) read from.
+      </p>
+      <div className="space-y-8">
+        {repos.map((entry) => (
+          <section key={entry.repo}>
+            <div className="mb-2 flex flex-wrap items-center gap-2">
+              <a
+                href={`https://github.com/${entry.repo}/releases`}
+                target="_blank"
+                rel="noreferrer"
+                className="font-barlow text-lg font-semibold hover:text-primary"
+              >
+                {entry.repo}
+              </a>
+              <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-primary dark:bg-white/10 dark:text-sky-300">
+                {entry.sport}
+              </span>
+            </div>
+            {entry.error ? (
+              <p className="font-inter text-sm text-red-600 dark:text-red-400">
+                Failed to load: {entry.error}
+              </p>
+            ) : entry.releases.length === 0 ? (
+              <p className="font-inter text-sm text-muted-foreground">No releases.</p>
+            ) : (
+              <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+                <table className="w-full text-left font-inter text-sm">
+                  <thead className="bg-gray-50 text-xs uppercase text-muted-foreground dark:bg-gray-800/60">
+                    <tr>
+                      <th className="px-4 py-2">Release</th>
+                      <th className="px-4 py-2">Assets</th>
+                      <th className="px-4 py-2">Total size</th>
+                      <th className="px-4 py-2">Published</th>
+                      <th className="px-4 py-2">Newest asset</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {entry.releases.map((rel) => (
+                      <tr key={rel.tag} className="border-t border-gray-200 dark:border-gray-700">
+                        <td className="px-4 py-2 font-medium">
+                          <a
+                            href={rel.html_url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="hover:text-primary"
+                          >
+                            {rel.name || rel.tag}
+                          </a>
+                        </td>
+                        <td className="px-4 py-2">{rel.asset_count}</td>
+                        <td className="px-4 py-2">{formatBytes(rel.total_size)}</td>
+                        <td className="px-4 py-2 text-muted-foreground">
+                          {timeAgo(rel.published_at)}
+                        </td>
+                        <td className="px-4 py-2 text-muted-foreground">
+                          {rel.assets[0]
+                            ? `${rel.assets[0].name} · ${timeAgo(rel.assets[0].updated_at)}`
+                            : "–"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        ))}
+      </div>
+    </PlatformShell>
+  );
+}
+
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
+  const session = await getPlatformSessionProps(ctx);
+  if (!session.authorized) {
+    return { props: { session, repos: [] } };
+  }
+  const tracked = PLATFORM_REPOS.filter((r) => r.hasReleases);
+  const settled = await Promise.allSettled(tracked.map((r) => listRepoReleases(r.repo)));
+  const repos: RepoReleases[] = tracked.map((entry, i) => {
+    const outcome = settled[i];
+    return {
+      repo: entry.repo,
+      sport: entry.sport,
+      releases: outcome.status === "fulfilled" ? outcome.value : [],
+      error:
+        outcome.status === "rejected"
+          ? outcome.reason instanceof Error
+            ? outcome.reason.message
+            : String(outcome.reason)
+          : null,
+    };
+  });
+  return { props: { session, repos } };
+}

--- a/frontend/pages/platform/index.tsx
+++ b/frontend/pages/platform/index.tsx
@@ -1,0 +1,116 @@
+import Link from "next/link";
+import type { GetServerSidePropsContext } from "next";
+import { Bot, Database, FlaskConical, HardDrive } from "lucide-react";
+import PlatformShell, { StatusBadge, timeAgo } from "@components/platform/PlatformShell";
+import { PLATFORM_REPOS } from "@content/platform";
+import type { PlatformSessionProps } from "@lib/platform/auth";
+import { getPlatformSessionProps } from "@lib/platform/auth";
+import { listDbStatuses } from "@lib/platform/dbStatus";
+import { listModels, listRuns } from "@lib/platform/runs";
+import type { DbStatusDoc, ModelRunDoc, ModelSummary } from "@lib/platform/schemas";
+
+type OverviewProps = {
+  session: PlatformSessionProps;
+  models: ModelSummary[];
+  recentRuns: ModelRunDoc[];
+  dbStatuses: DbStatusDoc[];
+};
+
+export default function PlatformOverview({
+  session,
+  models,
+  recentRuns,
+  dbStatuses,
+}: OverviewProps) {
+  const cards = [
+    {
+      href: "/platform/automation",
+      icon: Bot,
+      title: "Automation",
+      body: `${PLATFORM_REPOS.length} tracked repos — scraper & builder workflow status, manual dispatch.`,
+    },
+    {
+      href: "/platform/datasets",
+      icon: Database,
+      title: "Datasets",
+      body: `Release artifacts across ${PLATFORM_REPOS.filter((r) => r.hasReleases).length} data repos.`,
+    },
+    {
+      href: "/platform/models",
+      icon: FlaskConical,
+      title: "Models",
+      body: `${models.length} tracked model${models.length === 1 ? "" : "s"} — training runs, metrics, oracle gates.`,
+    },
+    {
+      href: "/platform/database",
+      icon: HardDrive,
+      title: "Database",
+      body: dbStatuses.length
+        ? `${dbStatuses.length} source${dbStatuses.length === 1 ? "" : "s"} reporting — latest heartbeat ${timeAgo(dbStatuses[0]?.collected_at)}.`
+        : "No heartbeats yet — wire the droplet cron (see SETUP-platform.md).",
+    },
+  ];
+
+  return (
+    <PlatformShell session={session} title="Overview">
+      <div className="grid gap-4 sm:grid-cols-2">
+        {cards.map((card) => (
+          <Link
+            key={card.href}
+            href={card.href}
+            className="rounded-lg border border-gray-200 bg-white/70 p-5 transition-colors hover:border-primary dark:border-gray-700 dark:bg-darkSecondary/70"
+          >
+            <div className="mb-2 flex items-center gap-2">
+              <card.icon className="h-5 w-5 text-primary" />
+              <span className="font-barlow text-lg font-semibold">{card.title}</span>
+            </div>
+            <p className="font-inter text-sm text-muted-foreground">{card.body}</p>
+          </Link>
+        ))}
+      </div>
+
+      <h2 className="mb-3 mt-10 font-barlow text-xl font-semibold">Recent runs</h2>
+      {recentRuns.length === 0 ? (
+        <p className="font-inter text-sm text-muted-foreground">
+          No runs recorded yet. POST one to <code>/api/platform/runs</code> — recipe in
+          SETUP-platform.md.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {recentRuns.map((run) => (
+            <Link
+              key={run._id}
+              href={`/platform/runs/${run._id}`}
+              className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-gray-200 bg-white/70 px-4 py-3 hover:border-primary dark:border-gray-700 dark:bg-darkSecondary/70"
+            >
+              <div className="flex items-center gap-3">
+                <StatusBadge status={run.status} />
+                <span className="font-barlow font-semibold">{run.model_id}</span>
+                <span className="font-inter text-sm text-muted-foreground">
+                  {run.run_name ?? run.sport}
+                </span>
+              </div>
+              <span className="font-inter text-xs text-muted-foreground">
+                {timeAgo(run.created_at)} · by {run.created_by}
+              </span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </PlatformShell>
+  );
+}
+
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
+  const session = await getPlatformSessionProps(ctx);
+  if (!session.authorized) {
+    return { props: { session, models: [], recentRuns: [], dbStatuses: [] } };
+  }
+  // Mongo-only reads (fast); GitHub calls stay on their own tabs.
+  const [models, recentRuns, dbStatuses] = await Promise.all([
+    listModels().catch(() => []),
+    listRuns({ limit: 8 }).catch(() => []),
+    listDbStatuses().catch(() => []),
+  ]);
+  return { props: { session, models, recentRuns, dbStatuses } };
+}

--- a/frontend/pages/platform/models/[modelId].tsx
+++ b/frontend/pages/platform/models/[modelId].tsx
@@ -1,0 +1,169 @@
+import Link from "next/link";
+import type { GetServerSidePropsContext } from "next";
+import { Check, X } from "lucide-react";
+import PlatformShell, {
+  Sparkline,
+  StatusBadge,
+  timeAgo,
+} from "@components/platform/PlatformShell";
+import type { PlatformSessionProps } from "@lib/platform/auth";
+import { getPlatformSessionProps } from "@lib/platform/auth";
+import { listRuns } from "@lib/platform/runs";
+import type { ModelRunDoc } from "@lib/platform/schemas";
+
+type ModelDetailProps = {
+  session: PlatformSessionProps;
+  modelId: string;
+  /** Newest-first, capped at 50. */
+  runs: ModelRunDoc[];
+};
+
+const MAX_GATE_COLUMNS = 10;
+
+export default function PlatformModelDetail({ session, modelId, runs }: ModelDetailProps) {
+  // Chronological order for trends; newest-first everywhere else.
+  const chrono = runs.slice().reverse();
+  const metricKeys = Array.from(new Set(chrono.flatMap((r) => Object.keys(r.metrics ?? {}))));
+  const gateNames = Array.from(
+    new Set(chrono.flatMap((r) => (r.gates ?? []).map((g) => g.name)))
+  );
+  const gateRuns = runs.slice(0, MAX_GATE_COLUMNS);
+
+  return (
+    <PlatformShell session={session} title={modelId}>
+      <div className="mb-6 flex flex-wrap items-center gap-3">
+        <h2 className="font-barlow text-2xl font-semibold">{modelId}</h2>
+        {runs[0] ? <StatusBadge status={runs[0].status} /> : null}
+        <span className="font-inter text-sm text-muted-foreground">
+          {runs.length} run{runs.length === 1 ? "" : "s"}
+          {runs[0] ? ` · latest ${timeAgo(runs[0].created_at)}` : ""}
+        </span>
+      </div>
+
+      {runs.length === 0 ? (
+        <p className="font-inter text-sm text-muted-foreground">
+          No runs recorded for this model.
+        </p>
+      ) : (
+        <>
+          {metricKeys.length > 0 ? (
+            <>
+              <h3 className="mb-3 font-barlow text-lg font-semibold">Metric trends</h3>
+              <div className="mb-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {metricKeys.map((key) => {
+                  const series = chrono
+                    .map((r) => r.metrics?.[key])
+                    .filter((v): v is number => typeof v === "number");
+                  const latest = series[series.length - 1];
+                  return (
+                    <div
+                      key={key}
+                      className="rounded-lg border border-gray-200 bg-white/70 px-4 py-3 dark:border-gray-700 dark:bg-darkSecondary/70"
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="truncate font-inter text-sm text-muted-foreground">
+                          {key}
+                        </span>
+                        <span className="font-barlow text-lg font-semibold">
+                          {latest !== undefined ? latest.toPrecision(4) : "–"}
+                        </span>
+                      </div>
+                      <Sparkline values={series} />
+                    </div>
+                  );
+                })}
+              </div>
+            </>
+          ) : null}
+
+          {gateNames.length > 0 ? (
+            <>
+              <h3 className="mb-3 font-barlow text-lg font-semibold">
+                Oracle gates <span className="font-inter text-sm font-normal text-muted-foreground">(newest {gateRuns.length} runs, newest first)</span>
+              </h3>
+              <div className="mb-8 overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+                <table className="w-full text-left font-inter text-sm">
+                  <thead className="bg-gray-50 text-xs uppercase text-muted-foreground dark:bg-gray-800/60">
+                    <tr>
+                      <th className="px-4 py-2">Gate</th>
+                      {gateRuns.map((run) => (
+                        <th key={run._id} className="px-2 py-2 text-center">
+                          <Link href={`/platform/runs/${run._id}`} className="hover:text-primary">
+                            {timeAgo(run.created_at)}
+                          </Link>
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {gateNames.map((name) => (
+                      <tr key={name} className="border-t border-gray-200 dark:border-gray-700">
+                        <td className="px-4 py-2 font-medium">{name}</td>
+                        {gateRuns.map((run) => {
+                          const gate = (run.gates ?? []).find((g) => g.name === name);
+                          return (
+                            <td key={run._id} className="px-2 py-2 text-center" title={
+                              gate
+                                ? `observed ${gate.observed} ${gate.comparison} ${gate.threshold}`
+                                : "not evaluated"
+                            }>
+                              {gate ? (
+                                gate.passed ? (
+                                  <Check className="inline h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+                                ) : (
+                                  <X className="inline h-4 w-4 text-red-600 dark:text-red-400" />
+                                )
+                              ) : (
+                                <span className="text-muted-foreground">–</span>
+                              )}
+                            </td>
+                          );
+                        })}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
+          ) : null}
+
+          <h3 className="mb-3 font-barlow text-lg font-semibold">Runs</h3>
+          <div className="space-y-2">
+            {runs.map((run) => (
+              <Link
+                key={run._id}
+                href={`/platform/runs/${run._id}`}
+                className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-gray-200 bg-white/70 px-4 py-3 hover:border-primary dark:border-gray-700 dark:bg-darkSecondary/70"
+              >
+                <div className="flex items-center gap-3">
+                  <StatusBadge status={run.status} />
+                  <span className="font-inter text-sm font-medium">
+                    {run.run_name ?? run._id.slice(-8)}
+                  </span>
+                  {run.git?.sha ? (
+                    <code className="font-mono text-xs text-muted-foreground">
+                      {run.git.sha.slice(0, 8)}
+                    </code>
+                  ) : null}
+                </div>
+                <span className="font-inter text-xs text-muted-foreground">
+                  {timeAgo(run.created_at)} · by {run.created_by}
+                </span>
+              </Link>
+            ))}
+          </div>
+        </>
+      )}
+    </PlatformShell>
+  );
+}
+
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
+  const session = await getPlatformSessionProps(ctx);
+  const modelId = typeof ctx.params?.modelId === "string" ? ctx.params.modelId : "";
+  if (!session.authorized) {
+    return { props: { session, modelId, runs: [] } };
+  }
+  const runs = await listRuns({ model_id: modelId, limit: 50 }).catch(() => []);
+  return { props: { session, modelId, runs } };
+}

--- a/frontend/pages/platform/models/index.tsx
+++ b/frontend/pages/platform/models/index.tsx
@@ -1,0 +1,89 @@
+import Link from "next/link";
+import type { GetServerSidePropsContext } from "next";
+import PlatformShell, { StatusBadge, timeAgo } from "@components/platform/PlatformShell";
+import type { PlatformSessionProps } from "@lib/platform/auth";
+import { getPlatformSessionProps } from "@lib/platform/auth";
+import { listModels } from "@lib/platform/runs";
+import type { ModelSummary } from "@lib/platform/schemas";
+
+type ModelsProps = {
+  session: PlatformSessionProps;
+  models: ModelSummary[];
+};
+
+export default function PlatformModels({ session, models }: ModelsProps) {
+  return (
+    <PlatformShell session={session} title="Models">
+      <p className="mb-6 font-inter text-sm text-muted-foreground">
+        One row per tracked model — grouped from ingested training runs. Gate counts
+        reflect the latest run.
+      </p>
+      {models.length === 0 ? (
+        <p className="font-inter text-sm text-muted-foreground">
+          Nothing tracked yet. POST a run to <code>/api/platform/runs</code> — recipe in
+          SETUP-platform.md.
+        </p>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+          <table className="w-full text-left font-inter text-sm">
+            <thead className="bg-gray-50 text-xs uppercase text-muted-foreground dark:bg-gray-800/60">
+              <tr>
+                <th className="px-4 py-2">Model</th>
+                <th className="px-4 py-2">Sport</th>
+                <th className="px-4 py-2">Runs</th>
+                <th className="px-4 py-2">Latest run</th>
+                <th className="px-4 py-2">Status</th>
+                <th className="px-4 py-2">Gates</th>
+              </tr>
+            </thead>
+            <tbody>
+              {models.map((model) => (
+                <tr key={model.model_id} className="border-t border-gray-200 dark:border-gray-700">
+                  <td className="px-4 py-2 font-medium">
+                    <Link
+                      href={`/platform/models/${model.model_id}`}
+                      className="hover:text-primary"
+                    >
+                      {model.model_id}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-2">{model.sport}</td>
+                  <td className="px-4 py-2">{model.run_count}</td>
+                  <td className="px-4 py-2 text-muted-foreground">
+                    {timeAgo(model.latest_run_at)}
+                  </td>
+                  <td className="px-4 py-2">
+                    <StatusBadge status={model.latest_status} />
+                  </td>
+                  <td className="px-4 py-2">
+                    {model.gates_total === 0 ? (
+                      <span className="text-muted-foreground">–</span>
+                    ) : (
+                      <StatusBadge
+                        status={model.gates_passed === model.gates_total ? "passed" : "failed"}
+                      />
+                    )}
+                    {model.gates_total > 0 ? (
+                      <span className="ml-2 text-xs text-muted-foreground">
+                        {model.gates_passed}/{model.gates_total}
+                      </span>
+                    ) : null}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </PlatformShell>
+  );
+}
+
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
+  const session = await getPlatformSessionProps(ctx);
+  if (!session.authorized) {
+    return { props: { session, models: [] } };
+  }
+  const models = await listModels().catch(() => []);
+  return { props: { session, models } };
+}

--- a/frontend/pages/platform/runs/[id].tsx
+++ b/frontend/pages/platform/runs/[id].tsx
@@ -1,0 +1,222 @@
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import type { GetServerSidePropsContext } from "next";
+import { ArrowLeft, Check, ExternalLink, Trash2, X } from "lucide-react";
+import PlatformShell, { StatusBadge, timeAgo } from "@components/platform/PlatformShell";
+import { Button } from "@components/ui/button";
+import type { PlatformSessionProps } from "@lib/platform/auth";
+import { getPlatformSessionProps } from "@lib/platform/auth";
+import { getRun } from "@lib/platform/runs";
+import type { ModelRunDoc } from "@lib/platform/schemas";
+
+type RunDetailProps = {
+  session: PlatformSessionProps;
+  run: ModelRunDoc | null;
+};
+
+function KeyValueTable({ data }: { data: Record<string, string | number | boolean> }) {
+  const entries = Object.entries(data);
+  if (entries.length === 0) {
+    return <p className="font-inter text-sm text-muted-foreground">None recorded.</p>;
+  }
+  return (
+    <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+      <table className="w-full text-left font-inter text-sm">
+        <tbody>
+          {entries.map(([key, value]) => (
+            <tr key={key} className="border-t border-gray-200 first:border-t-0 dark:border-gray-700">
+              <td className="px-4 py-2 font-medium">{key}</td>
+              <td className="px-4 py-2 font-mono text-xs">
+                {typeof value === "number" ? value.toPrecision(6) : String(value)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default function PlatformRunDetail({ session, run }: RunDetailProps) {
+  const router = useRouter();
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleDelete() {
+    if (!run) return;
+    if (!window.confirm(`Delete this ${run.model_id} run? This cannot be undone.`)) return;
+    setDeleting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/platform/runs/${run._id}`, { method: "DELETE" });
+      const data = await res.json();
+      if (!res.ok || !data.success) throw new Error(data.message || "Delete failed");
+      await router.push(`/platform/models/${run.model_id}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Delete failed");
+      setDeleting(false);
+    }
+  }
+
+  if (!run) {
+    return (
+      <PlatformShell session={session} title="Run not found">
+        <p className="font-inter text-sm text-muted-foreground">
+          Run not found.{" "}
+          <Link href="/platform/models" className="text-primary hover:underline">
+            Back to models
+          </Link>
+        </p>
+      </PlatformShell>
+    );
+  }
+
+  return (
+    <PlatformShell session={session} title={`${run.model_id} run`}>
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <Link
+            href={`/platform/models/${run.model_id}`}
+            className="inline-flex items-center gap-1 font-inter text-sm text-muted-foreground hover:text-primary"
+          >
+            <ArrowLeft className="h-4 w-4" /> {run.model_id}
+          </Link>
+          <h2 className="font-barlow text-2xl font-semibold">
+            {run.run_name ?? run._id.slice(-8)}
+          </h2>
+          <StatusBadge status={run.status} />
+        </div>
+        <Button variant="outline" size="sm" onClick={handleDelete} disabled={deleting}>
+          <Trash2 className="mr-1 h-4 w-4 text-red-600 dark:text-red-400" />
+          {deleting ? "Deleting…" : "Delete run"}
+        </Button>
+      </div>
+
+      {error ? (
+        <div className="mb-4 rounded-md border border-red-300 bg-red-50 px-4 py-3 font-inter text-sm text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300">
+          {error}
+        </div>
+      ) : null}
+
+      <p className="mb-6 font-inter text-sm text-muted-foreground">
+        {run.sport} · recorded {timeAgo(run.created_at)} by {run.created_by}
+        {run.started_at ? ` · started ${timeAgo(run.started_at)}` : ""}
+        {run.finished_at ? ` · finished ${timeAgo(run.finished_at)}` : ""}
+        {run.git?.repo ? (
+          <>
+            {" · "}
+            <a
+              href={`https://github.com/${run.git.repo}${run.git.sha ? `/commit/${run.git.sha}` : ""}`}
+              target="_blank"
+              rel="noreferrer"
+              className="text-primary hover:underline"
+            >
+              {run.git.repo}
+              {run.git.sha ? `@${run.git.sha.slice(0, 8)}` : ""}
+            </a>
+          </>
+        ) : null}
+      </p>
+
+      {run.tags.length > 0 ? (
+        <div className="mb-6 flex flex-wrap gap-2">
+          {run.tags.map((tag) => (
+            <span
+              key={tag}
+              className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary dark:bg-white/10 dark:text-sky-300"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      {run.gates.length > 0 ? (
+        <>
+          <h3 className="mb-3 font-barlow text-lg font-semibold">Oracle gates</h3>
+          <div className="mb-8 overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+            <table className="w-full text-left font-inter text-sm">
+              <thead className="bg-gray-50 text-xs uppercase text-muted-foreground dark:bg-gray-800/60">
+                <tr>
+                  <th className="px-4 py-2">Gate</th>
+                  <th className="px-4 py-2">Observed</th>
+                  <th className="px-4 py-2">Threshold</th>
+                  <th className="px-4 py-2">Result</th>
+                </tr>
+              </thead>
+              <tbody>
+                {run.gates.map((gate) => (
+                  <tr key={gate.name} className="border-t border-gray-200 dark:border-gray-700">
+                    <td className="px-4 py-2 font-medium">{gate.name}</td>
+                    <td className="px-4 py-2 font-mono text-xs">{gate.observed}</td>
+                    <td className="px-4 py-2 font-mono text-xs">
+                      {gate.comparison === "lte" ? "≤" : "≥"} {gate.threshold}
+                    </td>
+                    <td className="px-4 py-2">
+                      {gate.passed ? (
+                        <Check className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+                      ) : (
+                        <X className="h-4 w-4 text-red-600 dark:text-red-400" />
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      ) : null}
+
+      <div className="mb-8 grid gap-6 lg:grid-cols-2">
+        <div>
+          <h3 className="mb-3 font-barlow text-lg font-semibold">Metrics</h3>
+          <KeyValueTable data={run.metrics} />
+        </div>
+        <div>
+          <h3 className="mb-3 font-barlow text-lg font-semibold">Params</h3>
+          <KeyValueTable data={run.params} />
+        </div>
+      </div>
+
+      {run.artifacts.length > 0 ? (
+        <>
+          <h3 className="mb-3 font-barlow text-lg font-semibold">Artifacts</h3>
+          <ul className="mb-8 space-y-1">
+            {run.artifacts.map((artifact) => (
+              <li key={artifact.url}>
+                <a
+                  href={artifact.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1 font-inter text-sm text-primary hover:underline"
+                >
+                  {artifact.name} <ExternalLink className="h-3 w-3" />
+                </a>
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : null}
+
+      {run.notes ? (
+        <>
+          <h3 className="mb-3 font-barlow text-lg font-semibold">Notes</h3>
+          <p className="whitespace-pre-wrap font-inter text-sm text-muted-foreground">
+            {run.notes}
+          </p>
+        </>
+      ) : null}
+    </PlatformShell>
+  );
+}
+
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
+  const session = await getPlatformSessionProps(ctx);
+  const id = typeof ctx.params?.id === "string" ? ctx.params.id : "";
+  if (!session.authorized) {
+    return { props: { session, run: null } };
+  }
+  const run = await getRun(id).catch(() => null);
+  return { props: { session, run } };
+}

--- a/frontend/utils/utils.ts
+++ b/frontend/utils/utils.ts
@@ -10,6 +10,7 @@ export const navigationRoutes: string[] = [
   "stats",
   // "projects",
   "snippets",
+  "platform",
 ];
 
 export const snippetsImages: { [key: string]: string } = {


### PR DESCRIPTION
## Summary

Adds a members-only **`/platform`** area behind the existing GitHub-OAuth (NextAuth) org-membership layer — the same trust boundary as `/packages/manage`. Five surfaces:

- **Automation** — GitHub Actions workflow status across the tracked org repos (nfl/cfb/hoopR/wehoop/fastRhockey/baseballr data+raw repos, sdv-py), with `workflow_dispatch` "Run" buttons restricted to a per-repo allowlist in `content/platform.ts`. SWR auto-refresh every 60 s.
- **Datasets** — release artifacts (assets, sizes, freshness) across the `*-data` repos via the GitHub Releases API.
- **Models** — model-run tracking store (Mongo `model_runs`): CI POSTs runs (params, metrics, oracle gates, artifacts, git provenance) via a bearer ingest token; the registry aggregates runs by `model_id`.
- **Evaluation** — per-model metric-trend sparklines (dependency-free inline SVG), oracle-gate pass/fail matrix across runs, full run detail with delete.
- **Database** — Postgres warehouse heartbeats **pushed** by the sdv-data droplet cron (the DB's ports stay closed to the public internet); latest snapshot per source with a 26 h staleness flag.

## Security model

- Every `/platform` page and `/api/platform/*` route (GETs included) requires an active org-member session; non-members get the members-only prompt / 401.
- `POST /api/platform/runs` and `POST /api/platform/db-status` additionally accept `Authorization: Bearer $PLATFORM_INGEST_TOKEN` (timing-safe compare, fails closed when unset) for CI writers.
- `GH_PLATFORM_TOKEN` (fine-grained PAT) is server-side only; without it the GitHub tabs degrade to unauthenticated reads and dispatch is disabled.
- Dispatch is double-gated: org-member session **and** workflow-file allowlist.

## Setup / docs

- `frontend/SETUP-platform.md` — env vars, PAT scopes, CI ingest recipes (curl + Python), droplet heartbeat cron script.
- `.env.example` — `GH_PLATFORM_TOKEN`, `PLATFORM_INGEST_TOKEN`.
- Design doc: `docs/superpowers/specs/2026-07-11-platform-design.md`.

## Verification

- `npm run tsc` ✅ · `npm run lint` ✅ · `npm run build` ✅ (all 7 routes SSR-registered)
- New Mongo collections (`model_runs`, `db_status`) are created lazily on first write — no migration needed.

## After merge

1. Set `GH_PLATFORM_TOKEN` + `PLATFORM_INGEST_TOKEN` on Vercel.
2. Wire the droplet heartbeat cron (script in SETUP-platform.md).
3. Add a run-ingest step to the model-training CI jobs when convenient.

## Summary by Sourcery

Introduce a members-only /platform area with shared layout, navigation, and server-gated access for org members, providing automation, dataset, model run, evaluation, and database heartbeat views backed by new Mongo collections and GitHub integrations.

New Features:
- Add a /platform navigation entry and tabbed shell layout for authorized organization members with session-aware gating.
- Expose an Automation view summarizing GitHub Actions workflows per tracked repo with allowlisted manual dispatch capabilities.
- Expose a Datasets view aggregating GitHub Releases across configured data repos with asset and freshness summaries.
- Expose Models and Model detail views backed by a Mongo-based model_runs store for tracking runs, metrics, oracle gates, artifacts, and git provenance, including per-run detail and deletion.
- Expose a Database view reading pushed Postgres heartbeat snapshots from Mongo to show warehouse status, size, and per-dataset freshness.

Enhancements:
- Centralize platform configuration in content/platform.ts to define tracked repos, dataset inclusion, and dispatchable workflows.
- Add shared platform UI widgets (status badges, sparklines, time-ago and byte formatting) for consistent status and trend visualization.
- Introduce platform-specific auth helpers enforcing org-member-only access and supporting a bearer ingest token for CI writers.
- Add server-side GitHub REST helpers for listing workflows, dispatching workflows, and listing releases using a server-only PAT, with graceful degradation when unset.

Build:
- Extend .env.example to include GH_PLATFORM_TOKEN and PLATFORM_INGEST_TOKEN configuration for the platform ingestion and GitHub access.

Documentation:
- Add a platform setup guide detailing environment variables, CI ingest recipes for model runs and database heartbeats, and GitHub PAT requirements.
- Add a design document describing the platform architecture, auth model, data model, and non-goals for the new members-only area.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a members-only Platform area with an overview dashboard and navigation for Automation, Datasets, Models, and Database monitoring.
  * Added GitHub Actions status viewing and approved workflow triggering.
  * Added dataset release browsing with asset counts, sizes, and update times.
  * Added model run tracking, filtering, metrics, gate results, trends, details, and deletion.
  * Added database heartbeat status with stale-status handling.
* **Documentation**
  * Added setup guidance covering authentication, configuration, data ingestion, and platform usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->