### PR TITLE
fix(platform): /platform 500 — _app swallows the 'session' pageProp

### DIFF
--- a/frontend/pages/platform/.omc/state/sessions/0d4bee16-5cf0-4e99-af4f-2f1bb6fb560f/pre-tool-advisory-throttle.json
+++ b/frontend/pages/platform/.omc/state/sessions/0d4bee16-5cf0-4e99-af4f-2f1bb6fb560f/pre-tool-advisory-throttle.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "entries": {
+    "79a93d4a2f8f50b95f852280616242fee1855dc99a3c75211917f55e72e95fae": {
+      "last_emitted_at_ms": 1783802540231,
+      "message": "Use parallel execution for independent tasks. Use run_in_background for long operations (npm install, builds, tests)."
+    }
+  },
+  "updated_at": "2026-07-11T20:42:20.231Z"
+}

--- a/frontend/pages/platform/automation.tsx
+++ b/frontend/pages/platform/automation.tsx
@@ -15,7 +15,7 @@ const fetcher = async (url: string) => {
   return data.message as AutomationRepo[];
 };
 
-export default function PlatformAutomation({ session }: { session: PlatformSessionProps }) {
+export default function PlatformAutomation({ platformSession: session }: { platformSession: PlatformSessionProps }) {
   const { data, error, isLoading, mutate, isValidating } = useSWR(
     session.authorized ? "/api/platform/automation" : null,
     fetcher,
@@ -170,5 +170,5 @@ export default function PlatformAutomation({ session }: { session: PlatformSessi
 }
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
-  return { props: { session: await getPlatformSessionProps(ctx) } };
+  return { props: { platformSession: await getPlatformSessionProps(ctx) } };
 }

--- a/frontend/pages/platform/database.tsx
+++ b/frontend/pages/platform/database.tsx
@@ -6,7 +6,7 @@ import { listDbStatuses } from "@lib/platform/dbStatus";
 import type { DbStatusDoc } from "@lib/platform/schemas";
 
 type DatabaseProps = {
-  session: PlatformSessionProps;
+  platformSession: PlatformSessionProps;
   statuses: DbStatusDoc[];
 };
 
@@ -19,7 +19,7 @@ function statusOf(status: DbStatusDoc): string {
   return Number.isNaN(age) || age > STALE_AFTER_MS ? "stale" : "ok";
 }
 
-export default function PlatformDatabase({ session, statuses }: DatabaseProps) {
+export default function PlatformDatabase({ platformSession: session, statuses }: DatabaseProps) {
   return (
     <PlatformShell session={session} title="Database">
       <p className="mb-6 font-inter text-sm text-muted-foreground">
@@ -131,8 +131,8 @@ export default function PlatformDatabase({ session, statuses }: DatabaseProps) {
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const session = await getPlatformSessionProps(ctx);
   if (!session.authorized) {
-    return { props: { session, statuses: [] } };
+    return { props: { platformSession: session, statuses: [] } };
   }
   const statuses = await listDbStatuses().catch(() => []);
-  return { props: { session, statuses } };
+  return { props: { platformSession: session, statuses } };
 }

--- a/frontend/pages/platform/datasets.tsx
+++ b/frontend/pages/platform/datasets.tsx
@@ -14,11 +14,11 @@ type RepoReleases = {
 };
 
 type DatasetsProps = {
-  session: PlatformSessionProps;
+  platformSession: PlatformSessionProps;
   repos: RepoReleases[];
 };
 
-export default function PlatformDatasets({ session, repos }: DatasetsProps) {
+export default function PlatformDatasets({ platformSession: session, repos }: DatasetsProps) {
   return (
     <PlatformShell session={session} title="Datasets">
       <p className="mb-6 font-inter text-sm text-muted-foreground">
@@ -98,7 +98,7 @@ export default function PlatformDatasets({ session, repos }: DatasetsProps) {
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const session = await getPlatformSessionProps(ctx);
   if (!session.authorized) {
-    return { props: { session, repos: [] } };
+    return { props: { platformSession: session, repos: [] } };
   }
   const tracked = PLATFORM_REPOS.filter((r) => r.hasReleases);
   const settled = await Promise.allSettled(tracked.map((r) => listRepoReleases(r.repo)));
@@ -116,5 +116,5 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
           : null,
     };
   });
-  return { props: { session, repos } };
+  return { props: { platformSession: session, repos } };
 }

--- a/frontend/pages/platform/index.tsx
+++ b/frontend/pages/platform/index.tsx
@@ -10,14 +10,14 @@ import { listModels, listRuns } from "@lib/platform/runs";
 import type { DbStatusDoc, ModelRunDoc, ModelSummary } from "@lib/platform/schemas";
 
 type OverviewProps = {
-  session: PlatformSessionProps;
+  platformSession: PlatformSessionProps;
   models: ModelSummary[];
   recentRuns: ModelRunDoc[];
   dbStatuses: DbStatusDoc[];
 };
 
 export default function PlatformOverview({
-  session,
+  platformSession: session,
   models,
   recentRuns,
   dbStatuses,
@@ -104,7 +104,7 @@ export default function PlatformOverview({
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const session = await getPlatformSessionProps(ctx);
   if (!session.authorized) {
-    return { props: { session, models: [], recentRuns: [], dbStatuses: [] } };
+    return { props: { platformSession: session, models: [], recentRuns: [], dbStatuses: [] } };
   }
   // Mongo-only reads (fast); GitHub calls stay on their own tabs.
   const [models, recentRuns, dbStatuses] = await Promise.all([
@@ -112,5 +112,5 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     listRuns({ limit: 8 }).catch(() => []),
     listDbStatuses().catch(() => []),
   ]);
-  return { props: { session, models, recentRuns, dbStatuses } };
+  return { props: { platformSession: session, models, recentRuns, dbStatuses } };
 }

--- a/frontend/pages/platform/models/[modelId].tsx
+++ b/frontend/pages/platform/models/[modelId].tsx
@@ -12,7 +12,7 @@ import { listRuns } from "@lib/platform/runs";
 import type { ModelRunDoc } from "@lib/platform/schemas";
 
 type ModelDetailProps = {
-  session: PlatformSessionProps;
+  platformSession: PlatformSessionProps;
   modelId: string;
   /** Newest-first, capped at 50. */
   runs: ModelRunDoc[];
@@ -20,7 +20,7 @@ type ModelDetailProps = {
 
 const MAX_GATE_COLUMNS = 10;
 
-export default function PlatformModelDetail({ session, modelId, runs }: ModelDetailProps) {
+export default function PlatformModelDetail({ platformSession: session, modelId, runs }: ModelDetailProps) {
   // Chronological order for trends; newest-first everywhere else.
   const chrono = runs.slice().reverse();
   const metricKeys = Array.from(new Set(chrono.flatMap((r) => Object.keys(r.metrics ?? {}))));
@@ -162,8 +162,8 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const session = await getPlatformSessionProps(ctx);
   const modelId = typeof ctx.params?.modelId === "string" ? ctx.params.modelId : "";
   if (!session.authorized) {
-    return { props: { session, modelId, runs: [] } };
+    return { props: { platformSession: session, modelId, runs: [] } };
   }
   const runs = await listRuns({ model_id: modelId, limit: 50 }).catch(() => []);
-  return { props: { session, modelId, runs } };
+  return { props: { platformSession: session, modelId, runs } };
 }

--- a/frontend/pages/platform/models/index.tsx
+++ b/frontend/pages/platform/models/index.tsx
@@ -7,11 +7,11 @@ import { listModels } from "@lib/platform/runs";
 import type { ModelSummary } from "@lib/platform/schemas";
 
 type ModelsProps = {
-  session: PlatformSessionProps;
+  platformSession: PlatformSessionProps;
   models: ModelSummary[];
 };
 
-export default function PlatformModels({ session, models }: ModelsProps) {
+export default function PlatformModels({ platformSession: session, models }: ModelsProps) {
   return (
     <PlatformShell session={session} title="Models">
       <p className="mb-6 font-inter text-sm text-muted-foreground">
@@ -82,8 +82,8 @@ export default function PlatformModels({ session, models }: ModelsProps) {
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const session = await getPlatformSessionProps(ctx);
   if (!session.authorized) {
-    return { props: { session, models: [] } };
+    return { props: { platformSession: session, models: [] } };
   }
   const models = await listModels().catch(() => []);
-  return { props: { session, models } };
+  return { props: { platformSession: session, models } };
 }

--- a/frontend/pages/platform/runs/[id].tsx
+++ b/frontend/pages/platform/runs/[id].tsx
@@ -11,7 +11,7 @@ import { getRun } from "@lib/platform/runs";
 import type { ModelRunDoc } from "@lib/platform/schemas";
 
 type RunDetailProps = {
-  session: PlatformSessionProps;
+  platformSession: PlatformSessionProps;
   run: ModelRunDoc | null;
 };
 
@@ -38,7 +38,7 @@ function KeyValueTable({ data }: { data: Record<string, string | number | boolea
   );
 }
 
-export default function PlatformRunDetail({ session, run }: RunDetailProps) {
+export default function PlatformRunDetail({ platformSession: session, run }: RunDetailProps) {
   const router = useRouter();
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -215,8 +215,8 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const session = await getPlatformSessionProps(ctx);
   const id = typeof ctx.params?.id === "string" ? ctx.params.id : "";
   if (!session.authorized) {
-    return { props: { session, run: null } };
+    return { props: { platformSession: session, run: null } };
   }
   const run = await getRun(id).catch(() => null);
-  return { props: { session, run } };
+  return { props: { platformSession: session, run } };
 }


### PR DESCRIPTION
Production hotfix: every /platform page 500'd (SSR) / threw client-side because `_app.tsx` destructures `session` out of `pageProps` for NextAuth's `SessionProvider` — so the platform pages' `session` gSSP prop never reached them and `PlatformShell` destructured `undefined` (`TypeError: Cannot destructure property 'authorized'`, confirmed in Vercel function logs). Renames the pageProp to `platformSession` (destructure-renamed back to `session` inside components, bodies untouched). tsc/lint/build green.

## Summary by Sourcery

Ensure platform pages receive their own session props without clashing with NextAuth’s SessionProvider by renaming the gSSP session prop and updating all platform page components accordingly.

Bug Fixes:
- Fix server-side and client-side errors on /platform routes caused by destructuring an undefined session prop in PlatformShell due to _app consuming the original session pageProp.

Enhancements:
- Align platform page props around a distinct platformSession field to avoid future naming conflicts with global auth session handling.