### PR TITLE
feat(platform): sport-grouped sportsdataverse-data releases with producer/log links

### DIFF
--- a/frontend/content/platform.ts
+++ b/frontend/content/platform.ts
@@ -95,3 +95,54 @@ export function isDispatchAllowed(repo: string, workflowFile: string): boolean {
   const entry = PLATFORM_REPOS.find((r) => r.repo === repo);
   return Boolean(entry?.dispatchable?.includes(workflowFile));
 }
+
+// ---------------------------------------------------------------------------
+// sportsdataverse-data release classification
+// ---------------------------------------------------------------------------
+
+export type ReleaseGroup = {
+  /** League/sport bucket the release belongs to (Datasets-page grouping key). */
+  sport: string;
+  /** Upstream data provider the release is scraped/derived from. */
+  provider: string;
+  /** owner/name of the repo whose jobs produce/refresh this release ("" = unknown). */
+  producer: string;
+};
+
+/**
+ * Ordered longest-prefix-first rules mapping sportsdataverse-data release
+ * tags to (sport, provider, producer). Grounded in the 154-tag inventory of
+ * 2026-07-11; a tag matching no rule lands in the "other" bucket, which is a
+ * signal to extend this table.
+ */
+const RELEASE_RULES: ({ prefix: string } & ReleaseGroup)[] = [
+  { prefix: "espn_cfb_model_", sport: "cfb", provider: "espn", producer: "sportsdataverse/cfbfastR-cfb-data" },
+  { prefix: "espn_cfb_adv_", sport: "cfb", provider: "espn", producer: "sportsdataverse/cfbfastR-cfb-data" },
+  { prefix: "espn_cfb_", sport: "cfb", provider: "espn", producer: "sportsdataverse/cfbfastR-data" },
+  { prefix: "cfbfastR_cfb_", sport: "cfb", provider: "cfbfastR", producer: "sportsdataverse/cfbfastR-data" },
+  { prefix: "espn_mens_college_basketball_", sport: "mbb", provider: "espn", producer: "sportsdataverse/hoopR-mbb-data" },
+  { prefix: "espn_womens_college_basketball_", sport: "wbb", provider: "espn", producer: "sportsdataverse/wehoop-wbb-data" },
+  { prefix: "espn_nba_", sport: "nba", provider: "espn", producer: "sportsdataverse/hoopR-nba-data" },
+  { prefix: "espn_wnba_", sport: "wnba", provider: "espn", producer: "sportsdataverse/wehoop-wnba-data" },
+  { prefix: "nba_stats_", sport: "nba", provider: "stats.nba.com", producer: "sportsdataverse/hoopR-nba-stats-data" },
+  { prefix: "wnba_stats_", sport: "wnba", provider: "stats.wnba.com", producer: "sportsdataverse/wehoop-wnba-stats-data" },
+  { prefix: "ncaa_baseball_", sport: "baseball", provider: "ncaa", producer: "sportsdataverse/baseballr-data" },
+  { prefix: "nfl_", sport: "nfl", provider: "nflverse/espn", producer: "sportsdataverse/nfl-data" },
+  { prefix: "nhl_", sport: "nhl", provider: "nhl api", producer: "sportsdataverse/fastRhockey-nhl-data" },
+  { prefix: "pwhl_", sport: "pwhl", provider: "hockeytech", producer: "sportsdataverse/fastRhockey-pwhl-data" },
+  { prefix: "phf_", sport: "phf", provider: "archived (league defunct)", producer: "sportsdataverse/fastRhockey-pwhl-data" },
+];
+
+export function classifyReleaseTag(tag: string): ReleaseGroup {
+  // Crosswalks: "<sport>_crosswalk", built by sportsdataverse-py tooling.
+  const crosswalk = tag.match(/^([a-z]+)_crosswalk$/);
+  if (crosswalk) {
+    return {
+      sport: crosswalk[1],
+      provider: "sportsdataverse",
+      producer: "sportsdataverse/sportsdataverse-py",
+    };
+  }
+  const rule = RELEASE_RULES.find((r) => tag.startsWith(r.prefix));
+  return rule ?? { sport: "other", provider: "—", producer: "" };
+}

--- a/frontend/lib/platform/github.ts
+++ b/frontend/lib/platform/github.ts
@@ -177,6 +177,8 @@ export type ReleaseSummary = {
   name: string | null;
   html_url: string;
   published_at: string | null;
+  /** Newest asset upload time — the real "last refreshed" for long-lived data releases. */
+  latest_asset_at: string | null;
   asset_count: number;
   total_size: number;
   assets: ReleaseAssetSummary[];
@@ -222,6 +224,7 @@ export async function listRepoReleases(repo: string, maxPages = 3): Promise<Rele
     name: rel.name,
     html_url: rel.html_url,
     published_at: rel.published_at,
+    latest_asset_at: newestAssetAt(rel) || null,
     asset_count: rel.assets.length,
     total_size: rel.assets.reduce((sum, a) => sum + a.size, 0),
     assets: rel.assets

--- a/frontend/pages/platform/datasets.tsx
+++ b/frontend/pages/platform/datasets.tsx
@@ -1,6 +1,7 @@
 import type { GetServerSidePropsContext } from "next";
+import { ScrollText } from "lucide-react";
 import PlatformShell, { formatBytes, timeAgo } from "@components/platform/PlatformShell";
-import { PLATFORM_REPOS } from "@content/platform";
+import { PLATFORM_REPOS, classifyReleaseTag } from "@content/platform";
 import type { PlatformSessionProps } from "@lib/platform/auth";
 import { getPlatformSessionProps } from "@lib/platform/auth";
 import { listRepoReleases, settlePool } from "@lib/platform/github";
@@ -18,12 +19,111 @@ type DatasetsProps = {
   repos: RepoReleases[];
 };
 
+/** The one repo whose releases are per-dataset (grouped by sport + producer-linked). */
+const DATA_MONOREPO = "sportsdataverse/sportsdataverse-data";
+
+function ProducerLink({ producer }: { producer: string }) {
+  if (!producer) return <span className="text-muted-foreground">–</span>;
+  const short = producer.split("/")[1] ?? producer;
+  return (
+    <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
+      <a
+        href={`https://github.com/${producer}`}
+        target="_blank"
+        rel="noreferrer"
+        className="hover:text-primary"
+      >
+        {short}
+      </a>
+      <a
+        href={`https://github.com/${producer}/actions`}
+        target="_blank"
+        rel="noreferrer"
+        title={`${short} workflow runs (logs)`}
+        aria-label={`${short} workflow logs`}
+        className="text-muted-foreground hover:text-primary"
+      >
+        <ScrollText className="h-3.5 w-3.5" />
+      </a>
+    </span>
+  );
+}
+
+function ReleaseTable({ releases, grouped }: { releases: ReleaseSummary[]; grouped: boolean }) {
+  return (
+    <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+      <table className="w-full text-left font-inter text-sm">
+        <thead className="bg-gray-50 text-xs uppercase text-muted-foreground dark:bg-gray-800/60">
+          <tr>
+            <th className="px-4 py-2">Release</th>
+            {grouped ? <th className="px-4 py-2">Provider</th> : null}
+            <th className="px-4 py-2">Assets</th>
+            <th className="px-4 py-2">Size</th>
+            <th className="px-4 py-2">Updated</th>
+            <th className="px-4 py-2">Published</th>
+            {grouped ? <th className="px-4 py-2">Producer / logs</th> : null}
+          </tr>
+        </thead>
+        <tbody>
+          {releases.map((rel) => {
+            const group = grouped ? classifyReleaseTag(rel.tag) : null;
+            return (
+              <tr key={rel.tag} className="border-t border-gray-200 dark:border-gray-700">
+                <td className="px-4 py-2 font-medium">
+                  <a
+                    href={rel.html_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="hover:text-primary"
+                    title={rel.assets[0] ? `newest asset: ${rel.assets[0].name}` : undefined}
+                  >
+                    {rel.name || rel.tag}
+                  </a>
+                </td>
+                {group ? (
+                  <td className="px-4 py-2 text-muted-foreground">{group.provider}</td>
+                ) : null}
+                <td className="px-4 py-2">{rel.asset_count}</td>
+                <td className="px-4 py-2">{formatBytes(rel.total_size)}</td>
+                <td className="px-4 py-2 text-muted-foreground">{timeAgo(rel.latest_asset_at)}</td>
+                <td className="px-4 py-2 text-muted-foreground">{timeAgo(rel.published_at)}</td>
+                {group ? (
+                  <td className="px-4 py-2">
+                    <ProducerLink producer={group.producer} />
+                  </td>
+                ) : null}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/** Group the data-monorepo's releases by sport, newest-activity group first. */
+function groupBySport(releases: ReleaseSummary[]): [string, ReleaseSummary[]][] {
+  const groups = new Map<string, ReleaseSummary[]>();
+  for (const rel of releases) {
+    const { sport } = classifyReleaseTag(rel.tag);
+    const bucket = groups.get(sport);
+    if (bucket) bucket.push(rel);
+    else groups.set(sport, [rel]);
+  }
+  // Releases arrive sorted by latest_asset_at desc, so each group's first
+  // entry is its freshest — order groups by that.
+  return Array.from(groups.entries()).sort((a, b) =>
+    (a[1][0]?.latest_asset_at ?? "") < (b[1][0]?.latest_asset_at ?? "") ? 1 : -1
+  );
+}
+
 export default function PlatformDatasets({ platformSession: session, repos }: DatasetsProps) {
   return (
     <PlatformShell session={session} title="Datasets">
       <p className="mb-6 font-inter text-sm text-muted-foreground">
         Release artifacts across the org&apos;s data repos — the distribution surface the
-        loaders (<code>load_*</code>) read from.
+        loaders (<code>load_*</code>) read from. sportsdataverse-data is grouped by
+        sport; each release links the repo whose jobs produce it.
       </p>
       <div className="space-y-8">
         {repos.map((entry) => (
@@ -40,6 +140,9 @@ export default function PlatformDatasets({ platformSession: session, repos }: Da
               <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-primary dark:bg-white/10 dark:text-sky-300">
                 {entry.sport}
               </span>
+              <span className="font-inter text-xs text-muted-foreground">
+                {entry.releases.length} release{entry.releases.length === 1 ? "" : "s"}
+              </span>
             </div>
             {entry.error ? (
               <p className="font-inter text-sm text-red-600 dark:text-red-400">
@@ -47,46 +150,22 @@ export default function PlatformDatasets({ platformSession: session, repos }: Da
               </p>
             ) : entry.releases.length === 0 ? (
               <p className="font-inter text-sm text-muted-foreground">No releases.</p>
-            ) : (
-              <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
-                <table className="w-full text-left font-inter text-sm">
-                  <thead className="bg-gray-50 text-xs uppercase text-muted-foreground dark:bg-gray-800/60">
-                    <tr>
-                      <th className="px-4 py-2">Release</th>
-                      <th className="px-4 py-2">Assets</th>
-                      <th className="px-4 py-2">Total size</th>
-                      <th className="px-4 py-2">Published</th>
-                      <th className="px-4 py-2">Newest asset</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {entry.releases.map((rel) => (
-                      <tr key={rel.tag} className="border-t border-gray-200 dark:border-gray-700">
-                        <td className="px-4 py-2 font-medium">
-                          <a
-                            href={rel.html_url}
-                            target="_blank"
-                            rel="noreferrer"
-                            className="hover:text-primary"
-                          >
-                            {rel.name || rel.tag}
-                          </a>
-                        </td>
-                        <td className="px-4 py-2">{rel.asset_count}</td>
-                        <td className="px-4 py-2">{formatBytes(rel.total_size)}</td>
-                        <td className="px-4 py-2 text-muted-foreground">
-                          {timeAgo(rel.published_at)}
-                        </td>
-                        <td className="px-4 py-2 text-muted-foreground">
-                          {rel.assets[0]
-                            ? `${rel.assets[0].name} · ${timeAgo(rel.assets[0].updated_at)}`
-                            : "–"}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+            ) : entry.repo === DATA_MONOREPO ? (
+              <div className="space-y-5">
+                {groupBySport(entry.releases).map(([sport, releases]) => (
+                  <div key={sport}>
+                    <h3 className="mb-2 font-barlow text-base font-semibold uppercase tracking-wide text-muted-foreground">
+                      {sport}{" "}
+                      <span className="font-inter text-xs font-normal normal-case">
+                        ({releases.length})
+                      </span>
+                    </h3>
+                    <ReleaseTable releases={releases} grouped />
+                  </div>
+                ))}
               </div>
+            ) : (
+              <ReleaseTable releases={entry.releases} grouped={false} />
             )}
           </section>
         ))}
@@ -116,5 +195,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
           : null,
     };
   });
+  // The data monorepo carries the canonical per-dataset releases — list it first.
+  repos.sort((a, b) => Number(b.repo === DATA_MONOREPO) - Number(a.repo === DATA_MONOREPO));
   return { props: { platformSession: session, repos } };
 }

--- a/frontend/pages/platform/datasets.tsx
+++ b/frontend/pages/platform/datasets.tsx
@@ -30,7 +30,7 @@ function ProducerLink({ producer }: { producer: string }) {
       <a
         href={`https://github.com/${producer}`}
         target="_blank"
-        rel="noreferrer"
+        rel="noreferrer noopener"
         className="hover:text-primary"
       >
         {short}
@@ -38,7 +38,7 @@ function ProducerLink({ producer }: { producer: string }) {
       <a
         href={`https://github.com/${producer}/actions`}
         target="_blank"
-        rel="noreferrer"
+        rel="noreferrer noopener"
         title={`${short} workflow runs (logs)`}
         aria-label={`${short} workflow logs`}
         className="text-muted-foreground hover:text-primary"
@@ -73,7 +73,7 @@ function ReleaseTable({ releases, grouped }: { releases: ReleaseSummary[]; group
                   <a
                     href={rel.html_url}
                     target="_blank"
-                    rel="noreferrer"
+                    rel="noreferrer noopener"
                     className="hover:text-primary"
                     title={rel.assets[0] ? `newest asset: ${rel.assets[0].name}` : undefined}
                   >
@@ -132,7 +132,7 @@ export default function PlatformDatasets({ platformSession: session, repos }: Da
               <a
                 href={`https://github.com/${entry.repo}/releases`}
                 target="_blank"
-                rel="noreferrer"
+                rel="noreferrer noopener"
                 className="font-barlow text-lg font-semibold hover:text-primary"
               >
                 {entry.repo}


### PR DESCRIPTION
Per feedback: sportsdataverse-data is the org's canonical per-dataset release surface, so its section on /platform/datasets is now grouped by sport/league (freshest group first, releases newest-asset-first within each), and every release row shows its upstream provider and links the repo whose jobs produce it (+ that repo's Actions page for logs).

`classifyReleaseTag` in content/platform.ts is the curated mapping — longest-prefix rules covering all 154 current tags (verified 100% against the live inventory: espn_cfb_* -> cfbfastR-data, espn_cfb_{adv,model}_* -> cfbfastR-cfb-data, espn_{m,w}ens_college_basketball_* -> hoopR-mbb/wehoop-wbb-data, nba_stats_*/wnba_stats_* -> the stats-data repos, nfl_* -> nfl-data, nhl_*/pwhl_*/phf_* -> fastRhockey repos, ncaa_baseball_* -> baseballr-data, *_crosswalk -> sportsdataverse-py). Unmatched future tags land in an 'other' group as a visible signal to extend the mapping.

All release tables also gain an **Updated** column (newest asset upload time) distinct from **Published** (release creation) — the meaningful freshness for long-lived re-uploaded data releases.

tsc/lint/build green.

## Summary by Sourcery

Group sportsdataverse-data releases by sport on the platform datasets page, surface producer and log links, and use latest asset upload time as the primary freshness indicator.

New Features:
- Add sport-based grouping for sportsdataverse-data releases, ordered by most recently refreshed groups and releases.
- Display upstream provider and producer repository (with workflow log link) for each sportsdataverse-data release on the datasets page.
- Show release counts per sport and list the sportsdataverse-data repository first in the datasets overview.

Enhancements:
- Unify release rendering through a reusable table component and adjust column labels to distinguish total size and timestamps.
- Introduce a curated tag classification mapping to derive sport, provider, and producer metadata for sportsdataverse-data releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added richer dataset release tables with release counts and clearer provider and producer details.
  - Grouped monorepo releases by sport and ordered groups by the most recently updated asset.
  - Added links to producer repositories and workflow logs where available.
  - Added release-tag classification to identify sport, provider, and producer information.

- **Improvements**
  - The primary dataset repository now appears first.
  - Release listings display the latest asset update timestamp for improved freshness visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->