### PR TITLE
feat(platform): /platform/explore — CFBD-exporter-style dataset query & CSV export

### DIFF
--- a/docs/superpowers/specs/2026-07-11-platform-design.md
+++ b/docs/superpowers/specs/2026-07-11-platform-design.md
@@ -155,6 +155,25 @@ a code change — deliberate, reviewable.
 - Status/gate badges: green/amber/red chips (lucide icons); sparklines are
   inline SVG. SWR for data with refresh intervals on the automation page.
 
+## Explore (added 2026-07-12 — CFBD-exporter emulation)
+
+Sixth surface: **`/platform/explore`** emulates collegefootballdata.com's
+exporter (recon 2026-07-11: searchable category catalog → parameter form →
+query → grid → CSV) over OUR release datasets:
+
+- **Engine:** DuckDB-WASM in the browser (jsDelivr bundles, lazy). Queries
+  parquet/csv release assets with HTTP range reads — only touched row groups
+  download; no server compute.
+- **CORS reality (verified by harness):** `github.com/releases/download` and
+  the signed `release-assets.githubusercontent.com` target send NO CORS
+  headers (OPTIONS → 405), so browsers cannot read release assets directly.
+  `/api/platform/datasets/file` is a member-gated same-origin Range-passthrough
+  proxy (server-side signed-URL resolve w/ 60 s cache, streams 206 ranges).
+- **Flow:** dataset picker (sportsdataverse-data tags grouped by sport via
+  `classifyReleaseTag`) → asset multi-select (`/api/platform/datasets/assets`,
+  full paginated list) → schema-aware filter builder (column/op/value + limit)
+  or free SQL mode → 500-row preview grid → full-result CSV download client-side.
+
 ## Phases (implementation order)
 
 1. **Foundation** — config, schemas, platform auth helper, PlatformShell,

--- a/frontend/components/platform/PlatformShell.tsx
+++ b/frontend/components/platform/PlatformShell.tsx
@@ -16,6 +16,7 @@ export const PLATFORM_TABS = [
   { href: "/platform", label: "Overview" },
   { href: "/platform/automation", label: "Automation" },
   { href: "/platform/datasets", label: "Datasets" },
+  { href: "/platform/explore", label: "Explore" },
   { href: "/platform/models", label: "Models" },
   { href: "/platform/database", label: "Database" },
 ] as const;

--- a/frontend/lib/platform/duckdb.ts
+++ b/frontend/lib/platform/duckdb.ts
@@ -1,0 +1,116 @@
+/**
+ * Client-only DuckDB-WASM engine for the /platform/explore exporter.
+ *
+ * Queries run entirely in the browser against GitHub release assets
+ * (parquet/csv) over HTTP range reads — no server, no egress through Vercel.
+ * The wasm bundle + worker load lazily from jsDelivr on first use, so the
+ * page bundle stays light and Next never has to webpack the wasm.
+ *
+ * Never import this from server code.
+ */
+
+import * as duckdb from "@duckdb/duckdb-wasm";
+
+let dbPromise: Promise<duckdb.AsyncDuckDB> | null = null;
+
+async function initDb(): Promise<duckdb.AsyncDuckDB> {
+  const bundles = duckdb.getJsDelivrBundles();
+  const bundle = await duckdb.selectBundle(bundles);
+  // Same-origin worker shim around the CDN-hosted worker script.
+  const workerUrl = URL.createObjectURL(
+    new Blob([`importScripts("${bundle.mainWorker}");`], { type: "text/javascript" })
+  );
+  const worker = new Worker(workerUrl);
+  const db = new duckdb.AsyncDuckDB(new duckdb.VoidLogger(), worker);
+  await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
+  URL.revokeObjectURL(workerUrl);
+  return db;
+}
+
+export function getDb(): Promise<duckdb.AsyncDuckDB> {
+  if (!dbPromise) dbPromise = initDb();
+  return dbPromise;
+}
+
+export type QueryResult = {
+  columns: string[];
+  /** Row-major values, stringified for display; null stays null. */
+  rows: (string | null)[][];
+  rowCount: number;
+};
+
+/** SELECT-source SQL for a set of release-asset URLs (parquet or csv). */
+export function sourceFor(urls: string[]): string {
+  const list = urls.map((u) => `'${u.replace(/'/g, "''")}'`).join(", ");
+  const isCsv = urls.every((u) => /\.csv(\.gz)?$/i.test(u));
+  return isCsv
+    ? `read_csv_auto([${list}], union_by_name=true)`
+    : `read_parquet([${list}], union_by_name=true)`;
+}
+
+function cellToString(value: unknown): string | null {
+  if (value == null) return null;
+  if (typeof value === "bigint") return value.toString();
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+export async function runQuery(sql: string, maxRows = 500): Promise<QueryResult> {
+  const db = await getDb();
+  const conn = await db.connect();
+  try {
+    const table = await conn.query(sql);
+    const columns = table.schema.fields.map((f) => f.name);
+    const rows: (string | null)[][] = [];
+    let count = 0;
+    outer: for (const batch of table.batches) {
+      for (let i = 0; i < batch.numRows; i++) {
+        if (rows.length >= maxRows) break outer;
+        const row: (string | null)[] = [];
+        for (let c = 0; c < columns.length; c++) {
+          row.push(cellToString(batch.getChildAt(c)?.get(i)));
+        }
+        rows.push(row);
+      }
+    }
+    count = table.numRows;
+    return { columns, rows, rowCount: count };
+  } finally {
+    await conn.close();
+  }
+}
+
+/** Escape one CSV cell per RFC 4180. */
+function csvCell(value: string | null): string {
+  if (value == null) return "";
+  return /[",\n\r]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+/**
+ * Run `sql` and stream the FULL result (no preview cap) into a CSV Blob.
+ * Kept in JS rather than COPY TO so no wasm filesystem round trip is needed.
+ */
+export async function queryToCsvBlob(sql: string): Promise<{ blob: Blob; rowCount: number }> {
+  const db = await getDb();
+  const conn = await db.connect();
+  try {
+    const table = await conn.query(sql);
+    const columns = table.schema.fields.map((f) => f.name);
+    const parts: string[] = [columns.map(csvCell).join(",") + "\n"];
+    for (const batch of table.batches) {
+      const lines: string[] = [];
+      for (let i = 0; i < batch.numRows; i++) {
+        const row: string[] = [];
+        for (let c = 0; c < columns.length; c++) {
+          row.push(csvCell(cellToString(batch.getChildAt(c)?.get(i))));
+        }
+        lines.push(row.join(","));
+      }
+      if (lines.length) parts.push(lines.join("\n") + "\n");
+    }
+    return { blob: new Blob(parts, { type: "text/csv" }), rowCount: table.numRows };
+  } finally {
+    await conn.close();
+  }
+}

--- a/frontend/lib/platform/github.ts
+++ b/frontend/lib/platform/github.ts
@@ -185,6 +185,7 @@ export type ReleaseSummary = {
 };
 
 type GhRelease = {
+  id: number;
   tag_name: string;
   name: string | null;
   html_url: string;
@@ -197,6 +198,36 @@ type GhRelease = {
     browser_download_url: string;
   }[];
 };
+
+/**
+ * FULL asset list for one release tag (the release object's embedded assets
+ * cap at ~100; the assets endpoint paginates). Feeds the explore asset picker.
+ */
+export async function listReleaseAssets(repo: string, tag: string): Promise<ReleaseAssetSummary[]> {
+  const release = await ghGet<GhRelease>(
+    `/repos/${repo}/releases/tags/${encodeURIComponent(tag)}`
+  );
+  let raw = release.assets;
+  if (raw.length >= 100) {
+    raw = [];
+    for (let page = 1; page <= 5; page++) {
+      const batch = await ghGet<GhRelease["assets"]>(
+        `/repos/${repo}/releases/${release.id}/assets?per_page=100&page=${page}`
+      );
+      raw.push(...batch);
+      if (batch.length < 100) break;
+    }
+  }
+  return raw
+    .map((a) => ({
+      name: a.name,
+      size: a.size,
+      download_count: a.download_count,
+      updated_at: a.updated_at,
+      browser_download_url: a.browser_download_url,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
 
 /**
  * A repo's releases — ALL of them (paginated up to `maxPages`×100; the org's

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
+        "@duckdb/duckdb-wasm": "^1.33.1-dev57.0",
         "@emailjs/browser": "^4.4.1",
         "@google-analytics/data": "^5.1.0",
         "@mailchimp/mailchimp_marketing": "^3.0.80",
@@ -360,6 +361,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@duckdb/duckdb-wasm": {
+      "version": "1.33.1-dev57.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.33.1-dev57.0.tgz",
+      "integrity": "sha512-ndn5l2EHq1PEMvCg8G6lRV0vjhSUcbqdM/niNBTTqH4/PyyUUVKbge0uUyCnj27b9SF/CiqBwDsgKLTqBvaxdw==",
+      "license": "MIT",
+      "dependencies": {
+        "apache-arrow": "^17.0.0",
+        "qs": "^6.14.1"
       }
     },
     "node_modules/@emailjs/browser": {
@@ -739,9 +750,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -757,9 +765,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -777,9 +782,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -795,9 +797,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -815,9 +814,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -833,9 +829,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -853,9 +846,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -872,9 +862,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -890,9 +877,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -916,9 +900,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -940,9 +921,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -966,9 +944,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -990,9 +965,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1016,9 +988,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1041,9 +1010,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1065,9 +1031,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1534,9 +1497,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1552,9 +1512,6 @@
       "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1572,9 +1529,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1590,9 +1544,6 @@
       "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2073,6 +2024,15 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@tailwindcss/typography": {
       "version": "0.5.20",
       "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz",
@@ -2095,6 +2055,18 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.13",
@@ -2789,6 +2761,35 @@
         "node": ">= 8"
       }
     },
+    "node_modules/apache-arrow": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-17.0.0.tgz",
+      "integrity": "sha512-X0p7auzdnGuhYMVKYINdQssS4EcKec9TCXyez/qtJt32DrIMGbzqiaMiQ0X6fQlQpw8Fl0Qygcv4dfRAr5Gu9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^20.13.0",
+        "command-line-args": "^5.2.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^24.3.25",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.cjs"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "dev": true,
@@ -2809,6 +2810,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/array-buffer-byte-length": {
@@ -3341,7 +3351,6 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -3352,6 +3361,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
       }
     },
     "node_modules/character-entities": {
@@ -3511,6 +3535,54 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
+      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.1",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/component-emitter": {
@@ -5017,6 +5089,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -5030,6 +5114,12 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/flatbuffers": {
+      "version": "24.12.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.12.23.tgz",
+      "integrity": "sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==",
+      "license": "Apache-2.0"
     },
     "node_modules/flatted": {
       "version": "3.4.2",
@@ -5528,7 +5618,6 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6588,6 +6677,14 @@
       "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/json-buffer": {
@@ -10123,7 +10220,6 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -10169,6 +10265,28 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/tailwind-merge": {
@@ -10616,6 +10734,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -11033,6 +11160,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/wrap-ansi": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "tsc": "tsc --noEmit"
   },
   "dependencies": {
+    "@duckdb/duckdb-wasm": "^1.33.1-dev57.0",
     "@emailjs/browser": "^4.4.1",
     "@google-analytics/data": "^5.1.0",
     "@mailchimp/mailchimp_marketing": "^3.0.80",

--- a/frontend/pages/api/platform/datasets/assets.ts
+++ b/frontend/pages/api/platform/datasets/assets.ts
@@ -1,0 +1,38 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { PLATFORM_REPOS } from "@content/platform";
+import { requireMember } from "@lib/platform/auth";
+import { GithubError, listReleaseAssets } from "@lib/platform/github";
+
+/**
+ * GET ?repo=<owner/name>&tag=<release tag> -> the release's FULL asset list
+ * (the Datasets page truncates to 20/release). Feeds the /platform/explore
+ * asset picker. Org-member only; repo must be a tracked release repo.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const actor = await requireMember(req, res);
+  if (!actor) return;
+
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ message: "Method not allowed", success: false });
+  }
+
+  const { repo, tag } = req.query;
+  if (typeof repo !== "string" || typeof tag !== "string" || !repo || !tag) {
+    return res.status(400).json({ message: "repo and tag are required.", success: false });
+  }
+  if (!PLATFORM_REPOS.some((r) => r.repo === repo && r.hasReleases)) {
+    return res.status(403).json({ message: `${repo} is not a tracked release repo.`, success: false });
+  }
+
+  try {
+    const assets = await listReleaseAssets(repo, tag);
+    return res.json({ message: assets, success: true });
+  } catch (error) {
+    const status = error instanceof GithubError ? error.status : 502;
+    return res.status(status >= 400 && status < 600 ? status : 502).json({
+      message: error instanceof Error ? error.message : "GitHub error",
+      success: false,
+    });
+  }
+}

--- a/frontend/pages/api/platform/datasets/file.ts
+++ b/frontend/pages/api/platform/datasets/file.ts
@@ -1,0 +1,109 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { PLATFORM_REPOS } from "@content/platform";
+import { requireMember } from "@lib/platform/auth";
+
+/**
+ * Same-origin Range-passthrough proxy for GitHub release assets.
+ *
+ * Why it exists: the /platform/explore DuckDB engine reads parquet via HTTP
+ * range requests, but GitHub's release-download redirect and its signed
+ * `release-assets.githubusercontent.com` target send NO CORS headers, so
+ * browsers cannot fetch them cross-origin at all. This route resolves the
+ * signed URL server-side and streams the requested byte range back on the
+ * SAME origin — no CORS, session auth rides along on the worker's XHR.
+ *
+ * GET/HEAD ?repo=<owner/name>&tag=<tag>&asset=<file>  (org member only)
+ */
+
+export const config = {
+  api: { responseLimit: false },
+};
+
+/** Signed-URL cache: GitHub's redirect targets live for minutes; 60s is safe. */
+const signedUrlCache = new Map<string, { url: string; at: number }>();
+const SIGNED_TTL_MS = 60_000;
+
+async function resolveSignedUrl(repo: string, tag: string, asset: string): Promise<string | null> {
+  const key = `${repo}/${tag}/${asset}`;
+  const hit = signedUrlCache.get(key);
+  if (hit && Date.now() - hit.at < SIGNED_TTL_MS) return hit.url;
+  const upstream = `https://github.com/${repo}/releases/download/${encodeURIComponent(tag)}/${encodeURIComponent(asset)}`;
+  const res = await fetch(upstream, { method: "HEAD", redirect: "manual" });
+  const location = res.headers.get("location");
+  if (!location) return null;
+  signedUrlCache.set(key, { url: location, at: Date.now() });
+  return location;
+}
+
+const FORWARD_RESPONSE_HEADERS = [
+  "content-length",
+  "content-range",
+  "accept-ranges",
+  "content-type",
+  "etag",
+  "last-modified",
+] as const;
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const actor = await requireMember(req, res);
+  if (!actor) return;
+
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    res.setHeader("Allow", "GET, HEAD");
+    return res.status(405).json({ message: "Method not allowed", success: false });
+  }
+
+  const { repo, tag, asset } = req.query;
+  if (
+    typeof repo !== "string" ||
+    typeof tag !== "string" ||
+    typeof asset !== "string" ||
+    !repo ||
+    !tag ||
+    !asset ||
+    asset.includes("/")
+  ) {
+    return res.status(400).json({ message: "repo, tag and asset are required.", success: false });
+  }
+  if (!PLATFORM_REPOS.some((r) => r.repo === repo && r.hasReleases)) {
+    return res
+      .status(403)
+      .json({ message: `${repo} is not a tracked release repo.`, success: false });
+  }
+
+  const signed = await resolveSignedUrl(repo, tag, asset);
+  if (!signed) {
+    return res.status(404).json({ message: "Asset not found.", success: false });
+  }
+
+  const headers: Record<string, string> = {};
+  if (typeof req.headers.range === "string") headers.Range = req.headers.range;
+
+  const upstream = await fetch(signed, { method: req.method, headers });
+  if (!upstream.ok && upstream.status !== 206) {
+    return res
+      .status(upstream.status === 404 ? 404 : 502)
+      .json({ message: `Upstream ${upstream.status}`, success: false });
+  }
+
+  res.status(upstream.status);
+  for (const name of FORWARD_RESPONSE_HEADERS) {
+    const value = upstream.headers.get(name);
+    if (value) res.setHeader(name, value);
+  }
+
+  if (req.method === "HEAD" || !upstream.body) {
+    return res.end();
+  }
+  // Stream the (possibly multi-MB) range straight through — never buffered.
+  const reader = upstream.body.getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      res.write(Buffer.from(value));
+    }
+  } finally {
+    res.end();
+  }
+}

--- a/frontend/pages/platform/explore.tsx
+++ b/frontend/pages/platform/explore.tsx
@@ -1,0 +1,426 @@
+import { useMemo, useState } from "react";
+import type { GetServerSidePropsContext } from "next";
+import useSWR from "swr";
+import { Download, Play, Plus, X } from "lucide-react";
+import PlatformShell, { formatBytes, timeAgo } from "@components/platform/PlatformShell";
+import { Button } from "@components/ui/button";
+import { classifyReleaseTag } from "@content/platform";
+import type { PlatformSessionProps } from "@lib/platform/auth";
+import { getPlatformSessionProps } from "@lib/platform/auth";
+import { listRepoReleases } from "@lib/platform/github";
+import type { ReleaseAssetSummary } from "@lib/platform/github";
+import type { QueryResult } from "@lib/platform/duckdb";
+
+/**
+ * CFBD-exporter-style data exploration: pick a dataset (release tag) → pick
+ * season assets → filter/query → preview grid → export CSV. Queries run
+ * entirely in the browser (DuckDB-WASM over release parquet/csv via HTTP
+ * range reads) — imported dynamically so none of it touches SSR.
+ */
+
+const DATA_REPO = "sportsdataverse/sportsdataverse-data";
+const QUERYABLE = /\.(parquet|csv|csv\.gz)$/i;
+
+type DatasetOption = { tag: string; sport: string; updated: string | null };
+
+type ExploreProps = {
+  platformSession: PlatformSessionProps;
+  datasets: DatasetOption[];
+  error: string | null;
+};
+
+type Filter = { column: string; op: string; value: string };
+
+const OPS = ["=", "!=", ">", ">=", "<", "<=", "contains"] as const;
+
+function sqlLiteral(value: string): string {
+  if (/^-?\d+(\.\d+)?$/.test(value.trim())) return value.trim();
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function buildSql(source: string, filters: Filter[], limit: number): string {
+  const where = filters
+    .filter((f) => f.column && f.value !== "")
+    .map((f) =>
+      f.op === "contains"
+        ? `CAST("${f.column}" AS VARCHAR) ILIKE '%${f.value.replace(/'/g, "''")}%'`
+        : `"${f.column}" ${f.op} ${sqlLiteral(f.value)}`
+    )
+    .join("\n  AND ");
+  return [
+    `SELECT *`,
+    `FROM ${source}`,
+    where ? `WHERE ${where}` : null,
+    `LIMIT ${Math.max(1, limit)}`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+const fetcher = async (url: string) => {
+  const res = await fetch(url);
+  const data = await res.json();
+  if (!res.ok || !data.success) throw new Error(data.message || "Request failed");
+  return data.message as ReleaseAssetSummary[];
+};
+
+export default function PlatformExplore({ platformSession: session, datasets, error }: ExploreProps) {
+  const [tag, setTag] = useState<string>("");
+  const [picked, setPicked] = useState<Set<string>>(new Set());
+  const [columns, setColumns] = useState<{ name: string; type: string }[]>([]);
+  const [filters, setFilters] = useState<Filter[]>([]);
+  const [limit, setLimit] = useState(100);
+  const [sql, setSql] = useState("");
+  const [sqlMode, setSqlMode] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [queryError, setQueryError] = useState<string | null>(null);
+  const [result, setResult] = useState<QueryResult | null>(null);
+
+  const { data: assets, error: assetsError, isLoading: assetsLoading } = useSWR(
+    session.authorized && tag
+      ? `/api/platform/datasets/assets?repo=${encodeURIComponent(DATA_REPO)}&tag=${encodeURIComponent(tag)}`
+      : null,
+    fetcher
+  );
+
+  const queryable = useMemo(() => (assets ?? []).filter((a) => QUERYABLE.test(a.name)), [assets]);
+
+  const grouped = useMemo(() => {
+    const bySport = new Map<string, DatasetOption[]>();
+    for (const d of datasets) {
+      const bucket = bySport.get(d.sport);
+      if (bucket) bucket.push(d);
+      else bySport.set(d.sport, [d]);
+    }
+    return Array.from(bySport.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+  }, [datasets]);
+
+  // Same-origin proxy URLs (api/platform/datasets/file): GitHub's release
+  // asset hosts send no CORS headers, so the browser can only range-read
+  // them through our own origin. Absolute URLs because DuckDB's worker
+  // resolves them outside the page's base URL. `asset` must remain the LAST
+  // query param — sourceFor() sniffs the file extension off the URL tail.
+  const pickedUrls = useMemo(
+    () =>
+      queryable
+        .filter((a) => picked.has(a.name))
+        .map(
+          (a) =>
+            `${window.location.origin}/api/platform/datasets/file?repo=${encodeURIComponent(DATA_REPO)}&tag=${encodeURIComponent(tag)}&asset=${encodeURIComponent(a.name)}`
+        ),
+    [queryable, picked, tag]
+  );
+
+  function selectTag(next: string) {
+    setTag(next);
+    setPicked(new Set());
+    setColumns([]);
+    setFilters([]);
+    setResult(null);
+    setSql("");
+    setQueryError(null);
+  }
+
+  function togglePicked(name: string) {
+    setPicked((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+    setColumns([]);
+    setResult(null);
+  }
+
+  async function withEngine<T>(label: string, fn: () => Promise<T>): Promise<T | null> {
+    setBusy(label);
+    setQueryError(null);
+    try {
+      return await fn();
+    } catch (e) {
+      setQueryError(e instanceof Error ? e.message : String(e));
+      return null;
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function loadSchema() {
+    const { runQuery, sourceFor } = await import("@lib/platform/duckdb");
+    await withEngine("Loading schema…", async () => {
+      const described = await runQuery(`DESCRIBE SELECT * FROM ${sourceFor(pickedUrls)}`, 1000);
+      const nameIdx = described.columns.indexOf("column_name");
+      const typeIdx = described.columns.indexOf("column_type");
+      setColumns(
+        described.rows.map((r) => ({ name: r[nameIdx] ?? "", type: r[typeIdx] ?? "" }))
+      );
+      setFilters([{ column: "", op: "=", value: "" }]);
+    });
+  }
+
+  async function run() {
+    const { runQuery, sourceFor } = await import("@lib/platform/duckdb");
+    const statement = sqlMode ? sql : buildSql(sourceFor(pickedUrls), filters, limit);
+    if (!sqlMode) setSql(statement);
+    await withEngine("Querying…", async () => {
+      setResult(await runQuery(statement, 500));
+    });
+  }
+
+  async function downloadCsv() {
+    const { queryToCsvBlob, sourceFor } = await import("@lib/platform/duckdb");
+    const statement = sqlMode ? sql : buildSql(sourceFor(pickedUrls), filters, limit);
+    await withEngine("Exporting…", async () => {
+      const { blob } = await queryToCsvBlob(statement);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${tag || "export"}.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    });
+  }
+
+  return (
+    <PlatformShell session={session} title="Explore">
+      <p className="mb-6 font-inter text-sm text-muted-foreground">
+        Query and export the org&apos;s release datasets — pick a dataset, choose season
+        files, filter, preview, download CSV. Queries run in your browser via DuckDB;
+        only the row groups you touch are downloaded.
+      </p>
+
+      {error ? (
+        <div className="mb-4 rounded-md border border-red-300 bg-red-50 px-4 py-3 font-inter text-sm text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300">
+          Failed to load the dataset catalog: {error}
+        </div>
+      ) : null}
+
+      {/* Step 1 — dataset */}
+      <h2 className="mb-2 font-barlow text-lg font-semibold">1 · Dataset</h2>
+      <select
+        value={tag}
+        onChange={(e) => selectTag(e.target.value)}
+        className="mb-6 w-full max-w-xl rounded-md border border-gray-300 bg-white px-3 py-2 font-inter text-sm dark:border-gray-600 dark:bg-darkSecondary"
+      >
+        <option value="">Select a dataset…</option>
+        {grouped.map(([sport, options]) => (
+          <optgroup key={sport} label={sport.toUpperCase()}>
+            {options.map((d) => (
+              <option key={d.tag} value={d.tag}>
+                {d.tag} · updated {timeAgo(d.updated)}
+              </option>
+            ))}
+          </optgroup>
+        ))}
+      </select>
+
+      {/* Step 2 — assets */}
+      {tag ? (
+        <>
+          <h2 className="mb-2 font-barlow text-lg font-semibold">2 · Files</h2>
+          {assetsError ? (
+            <p className="mb-4 font-inter text-sm text-red-600 dark:text-red-400">
+              {assetsError.message}
+            </p>
+          ) : assetsLoading ? (
+            <p className="mb-4 font-inter text-sm text-muted-foreground">Loading files…</p>
+          ) : queryable.length === 0 ? (
+            <p className="mb-4 font-inter text-sm text-muted-foreground">
+              No parquet/csv assets in this release.
+            </p>
+          ) : (
+            <div className="mb-6 grid max-h-56 gap-1 overflow-y-auto rounded-lg border border-gray-200 p-3 dark:border-gray-700 sm:grid-cols-2 lg:grid-cols-3">
+              {queryable.map((a) => (
+                <label key={a.name} className="flex items-center gap-2 font-mono text-xs">
+                  <input
+                    type="checkbox"
+                    checked={picked.has(a.name)}
+                    onChange={() => togglePicked(a.name)}
+                  />
+                  <span className="truncate" title={a.name}>
+                    {a.name}
+                  </span>
+                  <span className="ml-auto whitespace-nowrap text-muted-foreground">
+                    {formatBytes(a.size)}
+                  </span>
+                </label>
+              ))}
+            </div>
+          )}
+        </>
+      ) : null}
+
+      {/* Step 3 — query */}
+      {pickedUrls.length > 0 ? (
+        <>
+          <h2 className="mb-2 font-barlow text-lg font-semibold">3 · Query &amp; export</h2>
+          {columns.length === 0 ? (
+            <Button onClick={loadSchema} disabled={busy !== null}>
+              {busy ?? "Load schema"}
+            </Button>
+          ) : (
+            <div className="space-y-3">
+              <div className="flex flex-wrap items-center gap-3">
+                <label className="flex items-center gap-2 font-inter text-sm">
+                  <input type="checkbox" checked={sqlMode} onChange={(e) => setSqlMode(e.target.checked)} />
+                  SQL mode
+                </label>
+                <label className="flex items-center gap-2 font-inter text-sm">
+                  Limit
+                  <input
+                    type="number"
+                    value={limit}
+                    min={1}
+                    max={1_000_000}
+                    onChange={(e) => setLimit(Number(e.target.value) || 100)}
+                    className="w-24 rounded-md border border-gray-300 bg-white px-2 py-1 dark:border-gray-600 dark:bg-darkSecondary"
+                    disabled={sqlMode}
+                  />
+                </label>
+              </div>
+
+              {sqlMode ? (
+                <textarea
+                  value={sql}
+                  onChange={(e) => setSql(e.target.value)}
+                  rows={6}
+                  spellCheck={false}
+                  className="w-full rounded-md border border-gray-300 bg-white p-3 font-mono text-xs dark:border-gray-600 dark:bg-darkSecondary"
+                />
+              ) : (
+                <div className="space-y-2">
+                  {filters.map((f, i) => (
+                    <div key={i} className="flex flex-wrap items-center gap-2">
+                      <select
+                        value={f.column}
+                        onChange={(e) =>
+                          setFilters(filters.map((x, j) => (j === i ? { ...x, column: e.target.value } : x)))
+                        }
+                        className="rounded-md border border-gray-300 bg-white px-2 py-1 font-mono text-xs dark:border-gray-600 dark:bg-darkSecondary"
+                      >
+                        <option value="">column…</option>
+                        {columns.map((c) => (
+                          <option key={c.name} value={c.name}>
+                            {c.name} ({c.type})
+                          </option>
+                        ))}
+                      </select>
+                      <select
+                        value={f.op}
+                        onChange={(e) =>
+                          setFilters(filters.map((x, j) => (j === i ? { ...x, op: e.target.value } : x)))
+                        }
+                        className="rounded-md border border-gray-300 bg-white px-2 py-1 font-mono text-xs dark:border-gray-600 dark:bg-darkSecondary"
+                      >
+                        {OPS.map((op) => (
+                          <option key={op}>{op}</option>
+                        ))}
+                      </select>
+                      <input
+                        value={f.value}
+                        onChange={(e) =>
+                          setFilters(filters.map((x, j) => (j === i ? { ...x, value: e.target.value } : x)))
+                        }
+                        placeholder="value"
+                        className="w-44 rounded-md border border-gray-300 bg-white px-2 py-1 font-mono text-xs dark:border-gray-600 dark:bg-darkSecondary"
+                      />
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label="Remove filter"
+                        onClick={() => setFilters(filters.filter((_, j) => j !== i))}
+                      >
+                        <X className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  ))}
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setFilters([...filters, { column: "", op: "=", value: "" }])}
+                  >
+                    <Plus className="mr-1 h-3 w-3" /> Add filter
+                  </Button>
+                </div>
+              )}
+
+              <div className="flex flex-wrap gap-2">
+                <Button onClick={run} disabled={busy !== null}>
+                  <Play className="mr-1 h-4 w-4" /> {busy ?? "Run"}
+                </Button>
+                <Button variant="outline" onClick={downloadCsv} disabled={busy !== null}>
+                  <Download className="mr-1 h-4 w-4" /> Download CSV
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {queryError ? (
+            <div className="mt-4 rounded-md border border-red-300 bg-red-50 px-4 py-3 font-mono text-xs text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300">
+              {queryError}
+            </div>
+          ) : null}
+
+          {result ? (
+            <div className="mt-6">
+              <p className="mb-2 font-inter text-sm text-muted-foreground">
+                {result.rowCount.toLocaleString("en-US")} row{result.rowCount === 1 ? "" : "s"}
+                {result.rowCount > result.rows.length
+                  ? ` (showing first ${result.rows.length})`
+                  : ""}
+              </p>
+              <div className="max-h-[32rem] overflow-auto rounded-lg border border-gray-200 dark:border-gray-700">
+                <table className="w-full text-left font-mono text-xs">
+                  <thead className="sticky top-0 bg-gray-50 uppercase text-muted-foreground dark:bg-gray-800">
+                    <tr>
+                      {result.columns.map((c) => (
+                        <th key={c} className="whitespace-nowrap px-3 py-2">
+                          {c}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {result.rows.map((row, i) => (
+                      <tr key={i} className="border-t border-gray-200 dark:border-gray-700">
+                        {row.map((cell, j) => (
+                          <td key={j} className="max-w-[16rem] truncate whitespace-nowrap px-3 py-1" title={cell ?? ""}>
+                            {cell ?? ""}
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          ) : null}
+        </>
+      ) : null}
+    </PlatformShell>
+  );
+}
+
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
+  const session = await getPlatformSessionProps(ctx);
+  if (!session.authorized) {
+    return { props: { platformSession: session, datasets: [], error: null } };
+  }
+  try {
+    const releases = await listRepoReleases(DATA_REPO);
+    const datasets: DatasetOption[] = releases.map((rel) => ({
+      tag: rel.tag,
+      sport: classifyReleaseTag(rel.tag).sport,
+      updated: rel.latest_asset_at,
+    }));
+    return { props: { platformSession: session, datasets, error: null } };
+  } catch (error) {
+    return {
+      props: {
+        platformSession: session,
+        datasets: [],
+        error: error instanceof Error ? error.message : "GitHub error",
+      },
+    };
+  }
+}


### PR DESCRIPTION
Emulates the collegefootballdata.com exporter workflow (recon of the live site: searchable data-category catalog → parameter form → query → CSV) over **our own release datasets**, as a new members-only **Explore** tab:

1. **Dataset** — sportsdataverse-data release tags grouped by sport (reuses `classifyReleaseTag`), freshest first.
2. **Files** — the release's full asset list (`/api/platform/datasets/assets`, paginated past the embedded-100 cap), parquet/csv selectable.
3. **Query & export** — DuckDB-WASM in the browser: schema-aware filter builder (column/op/value + limit) or free SQL mode, 500-row preview grid, full-result CSV download. Only the row groups a query touches are downloaded (HTTP range reads).

**The CORS finding that shaped the design:** a browser harness proved GitHub's release-download redirect AND its signed `release-assets.githubusercontent.com` target send no CORS headers at all (OPTIONS → 405; no ACAO even with an Origin). Browsers cannot read release assets directly — so `/api/platform/datasets/file` is a member-gated, same-origin **Range-passthrough proxy**: resolves the signed URL server-side (60 s cache), forwards `Range`, streams 206 responses (`responseLimit: false`). Range semantics of the signed host verified (Accept-Ranges, 206 + correct bytes).

Verification: tsc/lint/build green; DuckDB engine + release-parquet range reads exercised in a real browser harness (failure mode above found exactly this way); the signed-URL resolve + 206 path verified with curl. The one thing that needs a signed-in click-through post-merge is the full in-app flow (org-member session required — errors surface in the UI banner with DuckDB's message if anything's off).

New dep: `@duckdb/duckdb-wasm` (wasm+worker load from jsDelivr at runtime; page bundle stays light).