### PR TITLE
feat(platform): lookups (player/team search) + saved Explore queries

### DIFF
--- a/frontend/components/platform/PlatformShell.tsx
+++ b/frontend/components/platform/PlatformShell.tsx
@@ -17,6 +17,7 @@ export const PLATFORM_TABS = [
   { href: "/platform/automation", label: "Automation" },
   { href: "/platform/datasets", label: "Datasets" },
   { href: "/platform/explore", label: "Explore" },
+  { href: "/platform/lookups", label: "Lookups" },
   { href: "/platform/models", label: "Models" },
   { href: "/platform/database", label: "Database" },
 ] as const;

--- a/frontend/content/lookups.ts
+++ b/frontend/content/lookups.ts
@@ -1,0 +1,86 @@
+/**
+ * Player/team lookup config for /platform/lookups — which release asset backs
+ * each sport's search and which columns to show. Column names verified against
+ * the live parquet schemas (2026-07-12). The `asset` pins the current-season
+ * file; roll it forward when a new season's rosters release lands.
+ */
+
+export type LookupSport = {
+  key: string;
+  label: string;
+  tag: string;
+  asset: string;
+  /** Column searched with ILIKE. */
+  nameCol: string;
+  /** Columns shown in the results grid, in order. */
+  columns: { col: string; label: string }[];
+  headshotCol?: string;
+  teamCol: string;
+};
+
+/** The four ESPN basketball roster releases share one 36-column shape. */
+const HOOPS_COLUMNS = [
+  { col: "full_name", label: "Player" },
+  { col: "team_display_name", label: "Team" },
+  { col: "position_abbreviation", label: "Pos" },
+  { col: "jersey", label: "#" },
+  { col: "height", label: "Ht" },
+  { col: "weight", label: "Wt" },
+  { col: "experience_years", label: "Exp" },
+  { col: "athlete_id", label: "ESPN id" },
+];
+
+const hoops = (key: string, label: string, tag: string, asset: string): LookupSport => ({
+  key,
+  label,
+  tag,
+  asset,
+  nameCol: "full_name",
+  columns: HOOPS_COLUMNS,
+  headshotCol: "headshot_href",
+  teamCol: "team_display_name",
+});
+
+export const LOOKUP_SPORTS: LookupSport[] = [
+  hoops("nba", "NBA", "espn_nba_rosters", "rosters_2026.parquet"),
+  hoops("wnba", "WNBA", "espn_wnba_rosters", "rosters_2026.parquet"),
+  hoops("mbb", "MBB", "espn_mens_college_basketball_rosters", "rosters_2026.parquet"),
+  hoops("wbb", "WBB", "espn_womens_college_basketball_rosters", "rosters_2026.parquet"),
+  {
+    key: "cfb",
+    label: "CFB",
+    tag: "espn_cfb_rosters",
+    asset: "rosters_2024.parquet",
+    nameCol: "display_name",
+    columns: [
+      { col: "display_name", label: "Player" },
+      { col: "team_display_name", label: "Team" },
+      { col: "jersey", label: "#" },
+      { col: "display_height", label: "Ht" },
+      { col: "display_weight", label: "Wt" },
+      { col: "experience_display_value", label: "Exp" },
+      { col: "athlete_id", label: "ESPN id" },
+    ],
+    headshotCol: "headshot_href",
+    teamCol: "team_display_name",
+  },
+  {
+    key: "nfl",
+    label: "NFL",
+    tag: "nfl_rosters",
+    asset: "roster_2024.parquet",
+    nameCol: "full_name",
+    columns: [
+      { col: "full_name", label: "Player" },
+      { col: "team", label: "Team" },
+      { col: "position", label: "Pos" },
+      { col: "jersey_number", label: "#" },
+      { col: "college", label: "College" },
+      { col: "years_exp", label: "Exp" },
+      { col: "gsis_id", label: "GSIS id" },
+      { col: "espn_id", label: "ESPN id" },
+    ],
+    headshotCol: "headshot_url",
+    teamCol: "team",
+  },
+];

--- a/frontend/lib/platform/bookmarks.ts
+++ b/frontend/lib/platform/bookmarks.ts
@@ -14,7 +14,17 @@ export async function listBookmarks(owner: string): Promise<BookmarkDoc[]> {
     .sort({ created_at: -1 })
     .limit(200)
     .toArray();
-  return docs.map((d: any) => ({ ...d, _id: String(d._id) }));
+  // Whitelist the contract fields — a spread would leak anything else that
+  // ever lands on the doc.
+  return docs.map((d: any) => ({
+    _id: String(d._id),
+    name: d.name,
+    tag: d.tag,
+    assets: d.assets,
+    sql: d.sql,
+    owner: d.owner,
+    created_at: d.created_at,
+  }));
 }
 
 export async function insertBookmark(bookmark: BookmarkInput, owner: string): Promise<string> {

--- a/frontend/lib/platform/bookmarks.ts
+++ b/frontend/lib/platform/bookmarks.ts
@@ -1,0 +1,36 @@
+import { ObjectId } from "mongodb";
+import { connectToDatabase } from "@lib/mongodb";
+import type { BookmarkDoc, BookmarkInput } from "./schemas";
+
+/** Owner-scoped saved Explore queries (`explore_bookmarks` collection). */
+
+const COLLECTION = "explore_bookmarks";
+
+export async function listBookmarks(owner: string): Promise<BookmarkDoc[]> {
+  const { db } = await connectToDatabase();
+  const docs = await db
+    .collection(COLLECTION)
+    .find({ owner })
+    .sort({ created_at: -1 })
+    .limit(200)
+    .toArray();
+  return docs.map((d: any) => ({ ...d, _id: String(d._id) }));
+}
+
+export async function insertBookmark(bookmark: BookmarkInput, owner: string): Promise<string> {
+  const { db } = await connectToDatabase();
+  const result = await db.collection(COLLECTION).insertOne({
+    ...bookmark,
+    owner,
+    created_at: new Date().toISOString(),
+  });
+  return String(result.insertedId);
+}
+
+/** Delete one of the owner's bookmarks; false when not found / not theirs. */
+export async function deleteBookmark(id: string, owner: string): Promise<boolean> {
+  if (!ObjectId.isValid(id)) return false;
+  const { db } = await connectToDatabase();
+  const result = await db.collection(COLLECTION).deleteOne({ _id: new ObjectId(id), owner });
+  return result.deletedCount === 1;
+}

--- a/frontend/lib/platform/schemas.ts
+++ b/frontend/lib/platform/schemas.ts
@@ -97,6 +97,21 @@ export type DbStatusDoc = DbStatusInput & {
   received_at: string;
 };
 
+/** A saved Explore query (Mongo `explore_bookmarks`, owner-scoped). */
+export const bookmarkSchema = z.object({
+  name: z.string().min(1).max(120),
+  tag: z.string().min(1).max(120),
+  assets: z.array(z.string().max(200)).min(1).max(50),
+  sql: z.string().min(1).max(10_000),
+});
+
+export type BookmarkInput = z.infer<typeof bookmarkSchema>;
+export type BookmarkDoc = BookmarkInput & {
+  _id: string;
+  owner: string;
+  created_at: string;
+};
+
 /** Registry aggregation row: one line per model_id. */
 export type ModelSummary = {
   model_id: string;

--- a/frontend/pages/api/platform/bookmarks.ts
+++ b/frontend/pages/api/platform/bookmarks.ts
@@ -1,0 +1,47 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { requireMember } from "@lib/platform/auth";
+import { deleteBookmark, insertBookmark, listBookmarks } from "@lib/platform/bookmarks";
+import { bookmarkSchema } from "@lib/platform/schemas";
+
+/**
+ * Saved Explore queries, scoped to the signed-in member.
+ * GET -> own bookmarks | POST -> save one | DELETE ?id= -> remove own.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const actor = await requireMember(req, res);
+  if (!actor) return;
+
+  try {
+    if (req.method === "GET") {
+      return res.json({ message: await listBookmarks(actor), success: true });
+    }
+
+    if (req.method === "POST") {
+      const parsed = bookmarkSchema.safeParse(req.body ?? {});
+      if (!parsed.success) {
+        return res.status(400).json({
+          message: "Validation failed",
+          errors: parsed.error.flatten(),
+          success: false,
+        });
+      }
+      const id = await insertBookmark(parsed.data, actor);
+      return res.status(201).json({ message: "Saved", id, success: true });
+    }
+
+    if (req.method === "DELETE") {
+      const id = typeof req.query.id === "string" ? req.query.id : "";
+      const deleted = await deleteBookmark(id, actor);
+      if (!deleted) return res.status(404).json({ message: "Not found", success: false });
+      return res.json({ message: "Deleted", success: true });
+    }
+  } catch (error) {
+    return res.status(500).json({
+      message: error instanceof Error ? error.message : "Database error",
+      success: false,
+    });
+  }
+
+  res.setHeader("Allow", "GET, POST, DELETE");
+  return res.status(405).json({ message: "Method not allowed", success: false });
+}

--- a/frontend/pages/platform/explore.tsx
+++ b/frontend/pages/platform/explore.tsx
@@ -1,7 +1,7 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { GetServerSidePropsContext } from "next";
-import useSWR from "swr";
-import { Download, Play, Plus, X } from "lucide-react";
+import useSWR, { mutate as swrMutate } from "swr";
+import { Bookmark, Download, Play, Plus, X } from "lucide-react";
 import PlatformShell, { formatBytes, timeAgo } from "@components/platform/PlatformShell";
 import { Button } from "@components/ui/button";
 import { classifyReleaseTag } from "@content/platform";
@@ -10,6 +10,7 @@ import { getPlatformSessionProps } from "@lib/platform/auth";
 import { listRepoReleases } from "@lib/platform/github";
 import type { ReleaseAssetSummary } from "@lib/platform/github";
 import type { QueryResult } from "@lib/platform/duckdb";
+import type { BookmarkDoc } from "@lib/platform/schemas";
 
 /**
  * CFBD-exporter-style data exploration: pick a dataset (release tag) → pick
@@ -84,6 +85,61 @@ export default function PlatformExplore({ platformSession: session, datasets, er
   );
 
   const queryable = useMemo(() => (assets ?? []).filter((a) => QUERYABLE.test(a.name)), [assets]);
+
+  const { data: bookmarks } = useSWR(
+    session.authorized ? "/api/platform/bookmarks" : null,
+    async (url: string) => {
+      const res = await fetch(url);
+      const data = await res.json();
+      if (!res.ok || !data.success) throw new Error(data.message || "Request failed");
+      return data.message as BookmarkDoc[];
+    }
+  );
+  const [pendingBookmark, setPendingBookmark] = useState<BookmarkDoc | null>(null);
+
+  // Applying a bookmark is two-phase: select its tag, then once that tag's
+  // asset list arrives, restore the picked files + SQL (in SQL mode).
+  useEffect(() => {
+    if (!pendingBookmark || pendingBookmark.tag !== tag || !assets) return;
+    const names = new Set(queryable.map((a) => a.name));
+    setPicked(new Set(pendingBookmark.assets.filter((a) => names.has(a))));
+    setSqlMode(true);
+    setSql(pendingBookmark.sql);
+    setPendingBookmark(null);
+  }, [pendingBookmark, tag, assets, queryable]);
+
+  async function saveBookmark() {
+    const name = window.prompt("Name this query:");
+    if (!name) return;
+    const statement = sqlMode
+      ? sql
+      : buildSql(
+          (await import("@lib/platform/duckdb")).sourceFor(pickedUrls),
+          filters,
+          limit
+        );
+    const res = await fetch("/api/platform/bookmarks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, tag, assets: Array.from(picked), sql: statement }),
+    });
+    const data = await res.json();
+    if (!res.ok || !data.success) {
+      setQueryError(data.message || "Save failed");
+      return;
+    }
+    await swrMutate("/api/platform/bookmarks");
+  }
+
+  function applyBookmark(bookmark: BookmarkDoc) {
+    setPendingBookmark(bookmark);
+    if (bookmark.tag !== tag) selectTag(bookmark.tag);
+  }
+
+  async function removeBookmark(id: string) {
+    await fetch(`/api/platform/bookmarks?id=${encodeURIComponent(id)}`, { method: "DELETE" });
+    await swrMutate("/api/platform/bookmarks");
+  }
 
   const grouped = useMemo(() => {
     const bySport = new Map<string, DatasetOption[]>();
@@ -195,6 +251,29 @@ export default function PlatformExplore({ platformSession: session, datasets, er
         </div>
       ) : null}
 
+      {bookmarks && bookmarks.length > 0 ? (
+        <div className="mb-6 flex flex-wrap items-center gap-2">
+          <span className="font-inter text-sm text-muted-foreground">Saved:</span>
+          {bookmarks.map((b) => (
+            <span
+              key={b._id}
+              className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary dark:bg-white/10 dark:text-sky-300"
+            >
+              <button onClick={() => applyBookmark(b)} title={`${b.tag} · ${b.assets.length} file(s)`}>
+                {b.name}
+              </button>
+              <button
+                onClick={() => removeBookmark(b._id)}
+                aria-label={`Delete saved query ${b.name}`}
+                className="text-muted-foreground hover:text-red-600"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+      ) : null}
+
       {/* Step 1 — dataset */}
       <h2 className="mb-2 font-barlow text-lg font-semibold">1 · Dataset</h2>
       <select
@@ -254,7 +333,7 @@ export default function PlatformExplore({ platformSession: session, datasets, er
       {pickedUrls.length > 0 ? (
         <>
           <h2 className="mb-2 font-barlow text-lg font-semibold">3 · Query &amp; export</h2>
-          {columns.length === 0 ? (
+          {columns.length === 0 && !sqlMode ? (
             <Button onClick={loadSchema} disabled={busy !== null}>
               {busy ?? "Load schema"}
             </Button>
@@ -350,6 +429,9 @@ export default function PlatformExplore({ platformSession: session, datasets, er
                 </Button>
                 <Button variant="outline" onClick={downloadCsv} disabled={busy !== null}>
                   <Download className="mr-1 h-4 w-4" /> Download CSV
+                </Button>
+                <Button variant="ghost" onClick={saveBookmark} disabled={busy !== null}>
+                  <Bookmark className="mr-1 h-4 w-4" /> Save query
                 </Button>
               </div>
             </div>

--- a/frontend/pages/platform/lookups.tsx
+++ b/frontend/pages/platform/lookups.tsx
@@ -1,0 +1,189 @@
+import { useMemo, useState } from "react";
+import type { GetServerSidePropsContext } from "next";
+import { Search } from "lucide-react";
+import PlatformShell from "@components/platform/PlatformShell";
+import { Button } from "@components/ui/button";
+import { LOOKUP_SPORTS } from "@content/lookups";
+import type { LookupSport } from "@content/lookups";
+import type { PlatformSessionProps } from "@lib/platform/auth";
+import { getPlatformSessionProps } from "@lib/platform/auth";
+import type { QueryResult } from "@lib/platform/duckdb";
+
+/**
+ * CFBD-style lookups: player search and team directory per sport, backed by
+ * the current-season roster parquet (content/lookups.ts) through the same
+ * DuckDB-WASM engine + range proxy the Explore tab uses.
+ */
+
+const DATA_REPO = "sportsdataverse/sportsdataverse-data";
+
+function proxyUrl(sport: LookupSport): string {
+  return `${window.location.origin}/api/platform/datasets/file?repo=${encodeURIComponent(DATA_REPO)}&tag=${encodeURIComponent(sport.tag)}&asset=${encodeURIComponent(sport.asset)}`;
+}
+
+export default function PlatformLookups({ platformSession: session }: { platformSession: PlatformSessionProps }) {
+  const [sportKey, setSportKey] = useState(LOOKUP_SPORTS[0].key);
+  const [mode, setMode] = useState<"players" | "teams">("players");
+  const [term, setTerm] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<QueryResult | null>(null);
+
+  const sport = useMemo(
+    () => LOOKUP_SPORTS.find((s) => s.key === sportKey) ?? LOOKUP_SPORTS[0],
+    [sportKey]
+  );
+
+  async function search() {
+    const { runQuery } = await import("@lib/platform/duckdb");
+    setBusy(true);
+    setError(null);
+    try {
+      const source = `read_parquet('${proxyUrl(sport)}')`;
+      let sql: string;
+      if (mode === "players") {
+        const cols = [
+          ...(sport.headshotCol ? [`"${sport.headshotCol}"`] : []),
+          ...sport.columns.map((c) => `"${c.col}"`),
+        ].join(", ");
+        const needle = term.replace(/'/g, "''");
+        sql = [
+          `SELECT ${cols} FROM ${source}`,
+          term ? `WHERE CAST("${sport.nameCol}" AS VARCHAR) ILIKE '%${needle}%'` : null,
+          `ORDER BY "${sport.nameCol}" LIMIT 100`,
+        ]
+          .filter(Boolean)
+          .join("\n");
+      } else {
+        sql = `SELECT "${sport.teamCol}" AS team, count(*)::INT AS players FROM ${source} GROUP BY 1 ORDER BY 1 LIMIT 400`;
+      }
+      setResult(await runQuery(sql, 400));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const headshotIdx = mode === "players" && sport.headshotCol && result ? 0 : -1;
+
+  return (
+    <PlatformShell session={session} title="Lookups">
+      <p className="mb-6 font-inter text-sm text-muted-foreground">
+        Player search and team directory per sport — current-season rosters, queried
+        in your browser. For historical seasons use the Explore tab.
+      </p>
+
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        {LOOKUP_SPORTS.map((s) => (
+          <button
+            key={s.key}
+            onClick={() => {
+              setSportKey(s.key);
+              setResult(null);
+            }}
+            className={`rounded-full px-3 py-1 font-inter text-sm font-medium transition-colors ${
+              s.key === sportKey
+                ? "bg-primary text-white dark:bg-white/20"
+                : "bg-primary/10 text-primary hover:bg-primary/20 dark:bg-white/10 dark:text-sky-300"
+            }`}
+          >
+            {s.label}
+          </button>
+        ))}
+        <span className="mx-2 text-muted-foreground">·</span>
+        {(["players", "teams"] as const).map((m) => (
+          <button
+            key={m}
+            onClick={() => {
+              setMode(m);
+              setResult(null);
+            }}
+            className={`rounded-full px-3 py-1 font-inter text-sm font-medium capitalize transition-colors ${
+              m === mode
+                ? "bg-primary text-white dark:bg-white/20"
+                : "bg-primary/10 text-primary hover:bg-primary/20 dark:bg-white/10 dark:text-sky-300"
+            }`}
+          >
+            {m}
+          </button>
+        ))}
+      </div>
+
+      <form
+        className="mb-6 flex max-w-xl gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void search();
+        }}
+      >
+        {mode === "players" ? (
+          <input
+            value={term}
+            onChange={(e) => setTerm(e.target.value)}
+            placeholder={`Search ${sport.label} players…`}
+            className="flex-1 rounded-md border border-gray-300 bg-white px-3 py-2 font-inter text-sm dark:border-gray-600 dark:bg-darkSecondary"
+          />
+        ) : null}
+        <Button type="submit" disabled={busy}>
+          <Search className="mr-1 h-4 w-4" />
+          {busy ? "Searching…" : mode === "players" ? "Search" : "List teams"}
+        </Button>
+      </form>
+
+      {error ? (
+        <div className="mb-4 rounded-md border border-red-300 bg-red-50 px-4 py-3 font-mono text-xs text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300">
+          {error}
+        </div>
+      ) : null}
+
+      {result ? (
+        <div className="max-h-[36rem] overflow-auto rounded-lg border border-gray-200 dark:border-gray-700">
+          <table className="w-full text-left font-inter text-sm">
+            <thead className="sticky top-0 bg-gray-50 text-xs uppercase text-muted-foreground dark:bg-gray-800">
+              <tr>
+                {headshotIdx === 0 ? <th className="px-3 py-2" /> : null}
+                {(mode === "players"
+                  ? sport.columns.map((c) => c.label)
+                  : ["Team", "Players"]
+                ).map((label) => (
+                  <th key={label} className="whitespace-nowrap px-3 py-2">
+                    {label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {result.rows.map((row, i) => (
+                <tr key={i} className="border-t border-gray-200 dark:border-gray-700">
+                  {headshotIdx === 0 ? (
+                    <td className="px-3 py-1">
+                      {row[0] ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={row[0]}
+                          alt=""
+                          loading="lazy"
+                          className="h-8 w-8 rounded-full object-cover"
+                        />
+                      ) : null}
+                    </td>
+                  ) : null}
+                  {row.slice(headshotIdx === 0 ? 1 : 0).map((cell, j) => (
+                    <td key={j} className="whitespace-nowrap px-3 py-1">
+                      {cell ?? ""}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+    </PlatformShell>
+  );
+}
+
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
+  return { props: { platformSession: await getPlatformSessionProps(ctx) } };
+}


### PR DESCRIPTION
Continues the CFBD emulation:

- **/platform/lookups** — player search + team directory for NBA/WNBA/MBB/WBB/CFB/NFL, backed by each sport's current-season roster parquet through the same DuckDB-WASM engine + same-origin range proxy Explore uses. Headshots, position/jersey/experience/provider-id columns. `content/lookups.ts` pins the season asset + column map per sport (all column names verified against the live parquet schemas — the four ESPN basketball releases share one 36-col shape; CFB and NFL have their own).
- **Saved queries in Explore** — Save query persists `{name, tag, assets, sql}` to an owner-scoped Mongo collection; saved chips restore dataset → files → SQL (two-phase apply after the tag's asset list loads) and delete inline. `/api/platform/bookmarks` GET/POST/DELETE, zod-validated, member-gated.

tsc/lint/build green. Same post-merge caveat as #15: in-app click-through needs an org-member session.

## Summary by Sourcery

Add platform player/team lookup page and member-scoped saved queries for Explore.

New Features:
- Introduce a Lookups tab that provides player search and team directory views across multiple sports using current-season roster data.
- Add saved query support to the Explore tab, allowing members to persist and restore dataset/file selections and SQL queries.

Bug Fixes:
- Prevent unnecessary schema loading in Explore when running saved SQL-mode queries.

Enhancements:
- Extend platform navigation to include the new Lookups tab.
- Update Explore to support SQL-only execution without requiring schema load when saving queries.