### PR TITLE
feat(platform): quick-query forms for top pbp datasets in Explore

### DIFF
--- a/frontend/content/presets.ts
+++ b/frontend/content/presets.ts
@@ -1,0 +1,72 @@
+/**
+ * Quick-query presets for /platform/explore — CFBD-exporter-style parameter
+ * forms for the most-used datasets: pick a season, fill 1-3 obvious fields,
+ * run. Column names verified against the live parquet schemas (2026-07-12).
+ * Datasets without a preset fall back to the generic asset picker + filter
+ * builder unchanged.
+ */
+
+export type QuickField = {
+  label: string;
+  /** Columns the value applies to; >1 means OR across them (contains only). */
+  cols: string[];
+  kind: "number" | "equals" | "contains";
+  placeholder?: string;
+};
+
+export type DatasetPreset = {
+  /** Season asset name prefix, e.g. "play_by_play_" -> play_by_play_2024.parquet */
+  assetPrefix: string;
+  fields: QuickField[];
+};
+
+const HOOPS_PBP_FIELDS: QuickField[] = [
+  {
+    label: "Team",
+    cols: ["home_team_name", "away_team_name"],
+    kind: "contains",
+    placeholder: "e.g. Duke",
+  },
+];
+
+export const EXPLORE_PRESETS: Record<string, DatasetPreset> = {
+  espn_cfb_pbp: {
+    assetPrefix: "play_by_play_",
+    fields: [
+      { label: "Week", cols: ["week"], kind: "number", placeholder: "1-15" },
+      { label: "Offense", cols: ["pos_team"], kind: "contains", placeholder: "e.g. Georgia" },
+    ],
+  },
+  nfl_model_pbp: {
+    assetPrefix: "model_pbp_",
+    fields: [
+      { label: "Week", cols: ["week"], kind: "number", placeholder: "1-18" },
+      { label: "Offense", cols: ["posteam"], kind: "equals", placeholder: "e.g. KC" },
+    ],
+  },
+  espn_mens_college_basketball_pbp: { assetPrefix: "play_by_play_", fields: HOOPS_PBP_FIELDS },
+  espn_womens_college_basketball_pbp: { assetPrefix: "play_by_play_", fields: HOOPS_PBP_FIELDS },
+  espn_nba_pbp: { assetPrefix: "play_by_play_", fields: HOOPS_PBP_FIELDS },
+  espn_wnba_pbp: { assetPrefix: "play_by_play_", fields: HOOPS_PBP_FIELDS },
+};
+
+/** WHERE clause for the filled quick fields; empty string when none filled. */
+export function quickWhere(fields: QuickField[], values: Record<string, string>): string {
+  const clauses: string[] = [];
+  for (const field of fields) {
+    const value = (values[field.label] ?? "").trim();
+    if (!value) continue;
+    const escaped = value.replace(/'/g, "''");
+    if (field.kind === "number") {
+      if (/^-?\d+(\.\d+)?$/.test(value)) clauses.push(`"${field.cols[0]}" = ${value}`);
+    } else if (field.kind === "equals") {
+      clauses.push(`upper(CAST("${field.cols[0]}" AS VARCHAR)) = upper('${escaped}')`);
+    } else {
+      const ors = field.cols.map(
+        (col) => `CAST("${col}" AS VARCHAR) ILIKE '%${escaped}%'`
+      );
+      clauses.push(ors.length > 1 ? `(${ors.join(" OR ")})` : ors[0]);
+    }
+  }
+  return clauses.join(" AND ");
+}

--- a/frontend/pages/platform/explore.tsx
+++ b/frontend/pages/platform/explore.tsx
@@ -5,6 +5,7 @@ import { Bookmark, Download, Play, Plus, X } from "lucide-react";
 import PlatformShell, { formatBytes, timeAgo } from "@components/platform/PlatformShell";
 import { Button } from "@components/ui/button";
 import { classifyReleaseTag } from "@content/platform";
+import { EXPLORE_PRESETS, quickWhere } from "@content/presets";
 import type { PlatformSessionProps } from "@lib/platform/auth";
 import { getPlatformSessionProps } from "@lib/platform/auth";
 import { listRepoReleases } from "@lib/platform/github";
@@ -167,8 +168,47 @@ export default function PlatformExplore({ platformSession: session, datasets, er
     [queryable, picked, tag]
   );
 
+  const preset = tag ? EXPLORE_PRESETS[tag] : undefined;
+  const [quickValues, setQuickValues] = useState<Record<string, string>>({});
+  const quickSeasons = useMemo(
+    () =>
+      preset
+        ? queryable
+            .map((a) => a.name)
+            .filter((n) => n.startsWith(preset.assetPrefix) && n.endsWith(".parquet"))
+            .sort()
+            .reverse()
+        : [],
+    [preset, queryable]
+  );
+  const [quickSeason, setQuickSeason] = useState("");
+
+  async function quickRun() {
+    if (!preset) return;
+    const asset = quickSeason || quickSeasons[0];
+    if (!asset) return;
+    const { runQuery } = await import("@lib/platform/duckdb");
+    const url = `${window.location.origin}/api/platform/datasets/file?repo=${encodeURIComponent(DATA_REPO)}&tag=${encodeURIComponent(tag)}&asset=${encodeURIComponent(asset)}`;
+    const where = quickWhere(preset.fields, quickValues);
+    const statement = [
+      `SELECT * FROM read_parquet('${url}')`,
+      where ? `WHERE ${where}` : null,
+      `LIMIT ${Math.max(1, limit)}`,
+    ]
+      .filter(Boolean)
+      .join("\n");
+    setPicked(new Set([asset]));
+    setSqlMode(true);
+    setSql(statement);
+    await withEngine("Querying…", async () => {
+      setResult(await runQuery(statement, 500));
+    });
+  }
+
   function selectTag(next: string) {
     setTag(next);
+    setQuickValues({});
+    setQuickSeason("");
     setPicked(new Set());
     setColumns([]);
     setFilters([]);
@@ -292,6 +332,51 @@ export default function PlatformExplore({ platformSession: session, datasets, er
           </optgroup>
         ))}
       </select>
+
+      {preset && quickSeasons.length > 0 ? (
+        <div className="mb-8 rounded-lg border border-primary/30 bg-primary/5 p-4 dark:border-sky-800 dark:bg-sky-950/20">
+          <h2 className="mb-3 font-barlow text-lg font-semibold">Quick query</h2>
+          <div className="flex flex-wrap items-end gap-3">
+            <label className="flex flex-col gap-1 font-inter text-xs text-muted-foreground">
+              Season
+              <select
+                value={quickSeason || quickSeasons[0]}
+                onChange={(e) => setQuickSeason(e.target.value)}
+                className="rounded-md border border-gray-300 bg-white px-2 py-1.5 text-sm text-foreground dark:border-gray-600 dark:bg-darkSecondary"
+              >
+                {quickSeasons.map((asset) => (
+                  <option key={asset} value={asset}>
+                    {asset.replace(preset.assetPrefix, "").replace(".parquet", "")}
+                  </option>
+                ))}
+              </select>
+            </label>
+            {preset.fields.map((field) => (
+              <label
+                key={field.label}
+                className="flex flex-col gap-1 font-inter text-xs text-muted-foreground"
+              >
+                {field.label}
+                <input
+                  value={quickValues[field.label] ?? ""}
+                  onChange={(e) =>
+                    setQuickValues({ ...quickValues, [field.label]: e.target.value })
+                  }
+                  placeholder={field.placeholder}
+                  className="w-36 rounded-md border border-gray-300 bg-white px-2 py-1.5 text-sm text-foreground dark:border-gray-600 dark:bg-darkSecondary"
+                />
+              </label>
+            ))}
+            <Button onClick={quickRun} disabled={busy !== null}>
+              <Play className="mr-1 h-4 w-4" /> {busy ?? "Run quick query"}
+            </Button>
+          </div>
+          <p className="mt-2 font-inter text-xs text-muted-foreground">
+            Runs against one season file with a 500-row preview; the generated SQL lands
+            in SQL mode below for tweaking or export.
+          </p>
+        </div>
+      ) : null}
 
       {/* Step 2 — assets */}
       {tag ? (


### PR DESCRIPTION
Fourth CFBD-emulation slice: the exporter's per-endpoint parameter forms. For the six pbp datasets (CFB, NFL model pbp, MBB/WBB/NBA/WNBA), Explore now shows a **Quick query** bar — season dropdown (auto-derived from the release's season assets) plus one or two verified fields (Week + Offense for football; team-contains across home/away names for basketball). Running it auto-selects the season file, generates the SQL, previews 500 rows, and leaves the statement in SQL mode for tweaking, saving, or CSV export.

Presets live in `content/presets.ts` (column names verified against the live parquet schemas; `quickWhere` handles number/equals/multi-column-contains with proper escaping). Datasets without a preset keep the generic asset-picker + filter-builder flow unchanged.

Also: SP+ Trends recon confirmed CFBD's analytics pages are public (no creds needed) — a team-metric multi-season Trends tool is the natural next slice.

tsc/lint/build green.