### PR TITLE
fix(platform): team directory truncated at 400 rows for college sports

### DIFF
--- a/frontend/pages/platform/lookups.tsx
+++ b/frontend/pages/platform/lookups.tsx
@@ -55,9 +55,11 @@ export default function PlatformLookups({ platformSession: session }: { platform
           .filter(Boolean)
           .join("\n");
       } else {
-        sql = `SELECT "${sport.teamCol}" AS team, count(*)::INT AS players FROM ${source} GROUP BY 1 ORDER BY 1 LIMIT 400`;
+        // No LIMIT: ESPN college roster files carry 900+ teams and a cap
+        // silently truncated the directory mid-alphabet.
+        sql = `SELECT "${sport.teamCol}" AS team, count(*)::INT AS players FROM ${source} GROUP BY 1 ORDER BY 1`;
       }
-      setResult(await runQuery(sql, 400));
+      setResult(await runQuery(sql, 2000));
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {


### PR DESCRIPTION
User-reported: the Lookups team directory cut off mid-alphabet for MBB/WBB — not pagination, but a LIMIT 400 on the teams query plus a 400-row preview cap, while ESPN's college roster files carry 900+ teams. Teams query is now uncapped with a 2000-row display ceiling. tsc/lint green.

## Summary by Sourcery

Bug Fixes:
- Resolve truncation of college sports team directories caused by a 400-row query and display limit.