### PR TITLE
fix(packages): drop published filter that blanked the public page

### DIFF
--- a/frontend/app/(site)/packages/page.tsx
+++ b/frontend/app/(site)/packages/page.tsx
@@ -19,12 +19,14 @@ export default async function PackagesPage() {
   let pkgs: any[] = [];
   try {
     const { db } = await connectToDatabase();
+    // No published filter: the legacy docs all carry published: false (the
+    // field predates the manage form's published-true default), so it is not
+    // a usable visibility flag for this collection.
     pkgs = JSON.parse(
       JSON.stringify(
         await db.collection("packages").find({}).sort({ title: 1 }).toArray()
       )
-      // Hidden entries (published: false) are manage-only — never public.
-    ).filter((p: any) => p.published !== false);
+    );
   } catch {
     pkgs = [];
   }


### PR DESCRIPTION
Prod regression from #24's leak-fix filter: all 25 live Mongo docs have `published: false` (the field predates the manage form's `published: true` default and was never a working visibility flag — the pre-migration site ignored it entirely). Filtering `published !== false` therefore hid every package.

This restores the unfiltered public listing. `/api/packages` was verified returning all 25 docs in prod, so connectivity was never the issue.

If draft-hiding is ever wanted: backfill `published: true` on the 25 legacy docs first, then reinstate the filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Packages page now displays all available package entries, including entries that were previously hidden.
  - Package listings remain sorted alphabetically by title for easier browsing.

- **Bug Fixes**
  - Improved package listing reliability by preserving graceful fallback behavior when package data cannot be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->