### PR TITLE
fix(content): repair broken images found by full-site link sweep

### DIFF
--- a/frontend/components/SnippetCard.tsx
+++ b/frontend/components/SnippetCard.tsx
@@ -4,15 +4,21 @@ import Image from "next/image";
 import Link from "next/link";
 
 // Language snippets get a styled monogram tile (matching the home-page
-// language chips); anything else falls back to the legacy icon images.
+// language chips); unknown keys fall back to a generic monogram rather than
+// a hotlinked icon (imgur rate-limits hotlinks).
 const LANG_TILES: Record<string, string> = {
   r: "R",
   python: "PY",
   node: "JS",
+  ts: "TS",
 };
 
 export default function SnippetCard({ snippet }: { snippet: Snippet }) {
-  const tile = LANG_TILES[snippet.image];
+  const tile =
+    LANG_TILES[snippet.image] ??
+    (snippetsImages[snippet.image]
+      ? undefined
+      : snippet.image.slice(0, 2).toUpperCase());
   return (
     <Link
       href={"/snippets/" + snippet.slug}

--- a/frontend/posts/chessR-for-chess-game-data.mdx
+++ b/frontend/posts/chessR-for-chess-game-data.mdx
@@ -16,7 +16,7 @@ ogImage:
 
 [![Version-Number](<https://img.shields.io/github/r-package/v/JaseZiv/chessR?label=chessR%20(Dev)>)](https://github.com/JaseZiv/chessR/)
 [![R build
-status](https://github.com/JaseZiv/chessR/workflows/R-CMD-check/badge.svg)](https://github.com/JaseZiv/chessR/actions)
+status](https://github.com/JaseZiv/chessR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/JaseZiv/chessR/actions)
 [![codecov](https://codecov.io/gh/JaseZiv/chessR/branch/master/graph/badge.svg?token=PE7LBUOWX7)](https://app.codecov.io/gh/JaseZiv/chessR)
 
 [![CRAN

--- a/frontend/posts/recruitR-for-college-sports-recruiting-data.mdx
+++ b/frontend/posts/recruitR-for-college-sports-recruiting-data.mdx
@@ -169,7 +169,7 @@ ggplot(SE_OTs_1k_grp ,aes(x = state_province, y = players, fill = factor(stars))
         plot.margin=unit(c(top=0.4,right=0.4,bottom=0.4,left=0.4),"cm"))
 ```
 
-<img src="man/figures/README-plot_OTs-1.png" width="100%" />
+<img src="https://raw.githubusercontent.com/sportsdataverse/recruitR/main/man/figures/README-plot_OTs-1.png" width="100%" />
 
 ## **Documentation**
 


### PR DESCRIPTION
Full crawl of prod (31 sitemap pages, 146 unique image/link URLs incl. Mongo-driven package/project fields): **142 OK**, 4 findings.

Fixed here:
- **chessR post**: R-CMD-check badge 404 → new `actions/workflows/R-CMD-check.yaml/badge.svg` form (verified 200)
- **recruitR post**: `<img src="man/figures/…">` was a *relative* path resolving against the page URL → absolute raw.githubusercontent (verified 200)
- **SnippetCard**: legacy `ts` snippet now renders a monogram tile instead of the imgur hotlink (imgur 429s hotlinks); unknown keys get a generic monogram instead of feeding `next/image` an undefined src

Not fixable from code — Mongo data: **sportyR `logoHref`** points at `sportyr-logo-hex.png` (404); correct file is `man/figures/logo.png` (200). Needs an org-member PUT via /api/packages.