### PR TITLE
fix(projects): contain cover images inside the card

### DIFF
--- a/frontend/components/OgImage.tsx
+++ b/frontend/components/OgImage.tsx
@@ -1,9 +1,11 @@
 // Project cover images are user-submitted (any domain), so we render a plain
 // <img> rather than next/image — next/image throws on a non-allowlisted remote
 // hostname, which would 500 the whole /projects page for one bad cover URL.
+// The wrapper is a fixed-aspect (mobile) / stretch-fill (desktop) box with
+// object-cover, so covers of any dimensions stay inside the card.
 function OgImage({ src, alt }: { src: string; alt: string }) {
   return (
-    <div className="relative -mt-10 sm:-mt-0 md:-ml-[35%] w-full sm:w-1/2 md:w-8/12 shrink-0 rounded-xl overflow-hidden shadow-2xl before:absolute before:inset-0 dark:before:bg-black/20 before:z-10">
+    <div className="relative aspect-[1200/630] w-full shrink-0 self-stretch overflow-hidden rounded-xl sm:aspect-auto sm:w-2/5 sm:min-h-40 before:absolute before:inset-0 dark:before:bg-black/20 before:z-10">
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         title={alt}
@@ -12,12 +14,7 @@ function OgImage({ src, alt }: { src: string; alt: string }) {
         loading="lazy"
         width={1200}
         height={630}
-        className="transition-all duration-300 lg:group-hover:scale-110 backdrop-blur-xl"
-        style={{
-          width: "100%",
-          height: "auto",
-          objectFit: "cover",
-        }}
+        className="absolute inset-0 h-full w-full object-cover transition-transform duration-300 lg:group-hover:scale-110"
       />
     </div>
   );

--- a/frontend/components/Project.tsx
+++ b/frontend/components/Project.tsx
@@ -11,10 +11,10 @@ export default function Project({ project }: { project: ProjectType }) {
     <div className="card">
       <OgImage src={cover} alt={project.name} />
 
-      <div className="flex flex-col justify-start gap-3">
-        <h1 className="font-bold text-foreground">
+      <div className="flex min-w-0 flex-1 flex-col justify-start gap-3">
+        <h2 className="font-bold text-foreground">
           {project.name}
-        </h1>
+        </h2>
         <p className="text-sm text-muted-foreground line-clamp-5">
           {project.description}
         </p>


### PR DESCRIPTION
Same class of bug as the blog-card fix in #24: `OgImage` hung covers outside the card on purpose (`md:-ml-[35%]` pop-out, `-mt-10` mobile bleed) and `height: auto` let arbitrary user-submitted cover dimensions set the card height. Covers now sit in a fixed-aspect (mobile) / stretch-fill (desktop) clipped box with `object-cover` — identical geometry to the blog cards, so the two card systems finally match.

Also: card titles were `<h1>` (one per project card) — demoted to `<h2>` to keep exactly one h1 per page.

Gates: tsc, lint, build all green. OgImage's only consumer is Project.tsx (verified).