### PR TITLE
feat(platform): warehouse-refresh toggle + package-freshness env badge

### DIFF
--- a/frontend/app/api/platform/orch/preflight/route.ts
+++ b/frontend/app/api/platform/orch/preflight/route.ts
@@ -1,0 +1,10 @@
+import { requireMemberApp } from "@lib/platform/auth";
+import { dataApi, forward } from "@lib/platform/orch";
+
+// Synchronous package-freshness audit: every SDV package clone vs origin +
+// installed version vs clone. Powers the env-health badge on the pipelines page.
+export async function GET() {
+  const { deny } = await requireMemberApp();
+  if (deny) return deny;
+  return forward(await dataApi("/v1/preflight"));
+}

--- a/frontend/components/platform/orch/EnvHealth.tsx
+++ b/frontend/components/platform/orch/EnvHealth.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import useSWR from "swr";
+import { CheckCircle2, AlertTriangle, Loader2 } from "lucide-react";
+import fetcher from "@lib/fetcher";
+import type { PreflightReport } from "@lib/platform/orch-types";
+import { Badge } from "@components/ui/badge";
+
+/**
+ * Package-freshness indicator. Reads the synchronous preflight audit (every SDV
+ * package clone vs origin + installed version vs clone) and renders a compact
+ * OK / N-stale badge. The same check runs as the first task of every pipeline
+ * run — this just makes the current state visible before you trigger one.
+ */
+export default function EnvHealth() {
+  const { data, error, isLoading } = useSWR<PreflightReport>(
+    "/api/platform/orch/preflight",
+    fetcher,
+    { revalidateOnFocus: false, refreshInterval: 600_000 }
+  );
+
+  if (isLoading) {
+    return (
+      <Badge variant="outline" className="gap-1 font-mono text-[10px]">
+        <Loader2 className="size-3 animate-spin" /> env
+      </Badge>
+    );
+  }
+  if (error || !data) {
+    return (
+      <Badge variant="outline" className="font-mono text-[10px] text-muted-foreground">
+        env check unavailable
+      </Badge>
+    );
+  }
+
+  const stale = Object.entries(data.packages).filter(([, v]) => !v.ok);
+  if (data.ok) {
+    return (
+      <Badge
+        variant="outline"
+        className="gap-1 border-status-success/40 font-mono text-[10px] text-status-success-ink dark:text-status-success"
+        title={`All ${data.known.length} package clones current with origin and installed`}
+      >
+        <CheckCircle2 className="size-3" /> env current
+      </Badge>
+    );
+  }
+  return (
+    <Badge
+      variant="outline"
+      className="gap-1 border-status-running/40 font-mono text-[10px] text-status-running-ink dark:text-status-running"
+      title={stale.map(([, v]) => v.findings.join("; ")).join("\n")}
+    >
+      <AlertTriangle className="size-3" />
+      {stale.length} package{stale.length === 1 ? "" : "s"} stale
+    </Badge>
+  );
+}

--- a/frontend/components/platform/orch/PipelinesPanel.tsx
+++ b/frontend/components/platform/orch/PipelinesPanel.tsx
@@ -5,6 +5,7 @@ import fetcher from "@lib/fetcher";
 import type { Pipeline } from "@lib/platform/orch-types";
 import TriggerForm from "./TriggerForm";
 import BudgetBadges from "./BudgetBadges";
+import EnvHealth from "./EnvHealth";
 import RunsTable from "./RunsTable";
 import { Card, CardContent, CardHeader, CardTitle } from "@components/ui/card";
 import { Skeleton } from "@components/ui/skeleton";
@@ -39,7 +40,10 @@ export default function PipelinesPanel() {
         <CardHeader className="pb-3">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <CardTitle className="font-display text-base">Trigger a run</CardTitle>
-            <BudgetBadges />
+            <div className="flex flex-wrap items-center gap-2">
+              <EnvHealth />
+              <BudgetBadges />
+            </div>
           </div>
         </CardHeader>
         <CardContent>
@@ -64,6 +68,33 @@ export default function PipelinesPanel() {
               <p className="font-mono text-xs text-muted-foreground">
                 seasons {p.season_min}–{p.season_max}
               </p>
+              <div className="mt-1 flex flex-wrap gap-1">
+                {p.cron ? (
+                  <span
+                    className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground"
+                    title={`Scheduled ${p.cron} (paused — activate in Prefect)`}
+                  >
+                    ⏱ {p.cron}
+                  </span>
+                ) : null}
+                {p.warehouse_sport ? (
+                  <span
+                    className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground"
+                    title="Can chain a warehouse refresh after the run"
+                  >
+                    ⛁ warehouse
+                  </span>
+                ) : null}
+                {p.packages.map((pkg) => (
+                  <span
+                    key={pkg}
+                    className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground"
+                    title="Preflight checks this package clone + install before each run"
+                  >
+                    {pkg}
+                  </span>
+                ))}
+              </div>
             </CardHeader>
             <CardContent className="flex flex-col gap-1.5">
               {p.stages.map((s) => (

--- a/frontend/components/platform/orch/TriggerForm.tsx
+++ b/frontend/components/platform/orch/TriggerForm.tsx
@@ -30,12 +30,14 @@ export default function TriggerForm({ pipelines }: { pipelines: Pipeline[] }) {
   const [end, setEnd] = useState<number | "">("");
   const [backfill, setBackfill] = useState(false);
   const [rescrape, setRescrape] = useState(false);
+  const [refreshWarehouse, setRefreshWarehouse] = useState(false);
   const [busy, setBusy] = useState(false);
 
   const selectedStages = stages ?? pipe?.default_stages ?? [];
   const rescrapeAvailable = pipe?.stages.some(
     (s) => selectedStages.includes(s.key) && s.supports_rescrape
   );
+  const warehouseAvailable = !!pipe?.warehouse_sport;
 
   function toggleStage(key: string) {
     const next = new Set(selectedStages);
@@ -59,6 +61,7 @@ export default function TriggerForm({ pipelines }: { pipelines: Pipeline[] }) {
           stages: stages, // null -> registry defaults
           rescrape: rescrapeAvailable ? rescrape : null,
           backfill,
+          refresh_warehouse: warehouseAvailable ? refreshWarehouse : false,
         }),
       });
       if (!res.ok) {
@@ -164,6 +167,20 @@ export default function TriggerForm({ pipelines }: { pipelines: Pipeline[] }) {
               className="accent-[var(--primary)]"
             />
             rescrape
+          </label>
+        ) : null}
+        {warehouseAvailable ? (
+          <label
+            className="flex items-center gap-2 pb-2 font-mono text-xs text-muted-foreground"
+            title={`After the run, re-ingest ${pipe.warehouse_sport} into the warehouse (data.sportsdataverse.org)`}
+          >
+            <input
+              type="checkbox"
+              checked={refreshWarehouse}
+              onChange={(e) => setRefreshWarehouse(e.target.checked)}
+              className="accent-[var(--primary)]"
+            />
+            refresh warehouse
           </label>
         ) : null}
         <Button onClick={submit} disabled={busy || start === ""} className="gap-2">

--- a/frontend/lib/platform/orch-types.ts
+++ b/frontend/lib/platform/orch-types.ts
@@ -19,6 +19,12 @@ export interface Pipeline {
   label: string;
   season_min: number;
   season_max: number;
+  /** Daily schedule (paused deployment) if the pipeline has one, else null. */
+  cron: string | null;
+  /** SDV package clones this pipeline's scripts depend on (preflight targets). */
+  packages: string[];
+  /** sdv-db ingest slice refreshed when refresh_warehouse is set, else null. */
+  warehouse_sport: string | null;
   default_stages: string[];
   stages: PipelineStage[];
 }
@@ -71,6 +77,21 @@ export interface TriggerRequest {
   stages?: string[] | null;
   rescrape?: boolean | null;
   backfill?: boolean;
+  /** Chain an sdv-db warehouse refresh of this sport's slice after the run. */
+  refresh_warehouse?: boolean;
+  /** Override the package-freshness preflight mode: warn | strict | off. */
+  preflight?: string | null;
+}
+
+export interface PreflightPackage {
+  ok: boolean;
+  findings: string[];
+}
+
+export interface PreflightReport {
+  packages: Record<string, PreflightPackage>;
+  ok: boolean;
+  known: string[];
 }
 
 /** Prefect state names that mean a run is finished. */


### PR DESCRIPTION
Surfaces two new sdv-orch capabilities in the pipelines UI:

**Refresh warehouse** — a checkbox on the trigger form (only for pipelines that declare a `warehouse_sport`: cfb/mbb/wbb) that chains an `sdv-db` ingest of that league's season slice after the data stages complete.

**Env health badge** — reads the new `GET /v1/preflight` sync audit: every SDV package clone vs `origin/main` + installed version vs the clone's version. Renders `env current` (green) or `N packages stale` (amber, with findings on hover). This is the *same* check that now runs as the first task of every pipeline run — the badge just makes the state visible before you trigger. It's live-catching real drift today (hoopR 3.0.0<3.1.0, baseballr 1.6.0.9002<2.0.0).

Pipeline cards also now show each pipeline's cron (paused), warehouse capability, and preflight packages.

Backing sdv-orch work (registry 4→14 pipelines, preflight.py, warehouse chaining, paused daily-cron deployments) is committed on the droplet's sdv-orch master (33b645a); this PR is only the web surface. Gates: tsc + lint + build all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment health checks showing current, unavailable, or stale package status.
  * Added pipeline badges for schedules, warehouse chaining, and associated packages.
  * Added an option to refresh warehouse data when triggering eligible pipeline runs.
  * Added preflight status reporting for accessible environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->