### PR TITLE
feat(platform): surface the package CMS in the platform nav

### DIFF
--- a/frontend/components/platform/widgets.tsx
+++ b/frontend/components/platform/widgets.tsx
@@ -15,6 +15,7 @@ import {
   Boxes,
   HardDrive,
   KeyRound,
+  Package,
 } from "lucide-react";
 
 export type PlatformNavItem = {
@@ -41,7 +42,13 @@ export const PLATFORM_NAV: { title: string | null; items: PlatformNavItem[] }[] 
   },
   {
     title: "Operations",
-    items: [{ href: "/platform/automation", label: "Automation", icon: Workflow }],
+    items: [
+      { href: "/platform/automation", label: "Automation", icon: Workflow },
+      // The org-member package CMS (/packages/manage edits the R/Py/Node.js
+      // entries shown on /packages) lives on the public site where members
+      // rarely stumble onto it — surface it here where they already work.
+      { href: "/packages/manage", label: "Packages CMS", icon: Package },
+    ],
   },
   {
     title: "Models",


### PR DESCRIPTION
The org-member package CMS (`/packages/manage`, which edits the R/Py/Node.js package entries shown on `/packages`) lives on the public site where org members rarely stumble onto it.

One `PLATFORM_NAV` entry under **Operations** surfaces it in the desktop sidebar, mobile drawer, and ⌘K palette simultaneously (the nav is single-source). Since the route renders under the `(site)` layout, the platform active-state matcher can never false-match it.

`tsc` + `eslint` green.

## Summary by Sourcery

New Features:
- Add a Packages CMS entry to the Operations section of the platform navigation, available in sidebar, mobile drawer, and command palette.