### PR TITLE
feat(platform): linked chart-table hover, row selection, DnD ordering, glossary tooltips

### DIFF
--- a/frontend/app/(platform)/platform/wp/WpClient.tsx
+++ b/frontend/app/(platform)/platform/wp/WpClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import useSWR from "swr";
 import { LineChart } from "lucide-react";
 import { Button } from "@components/ui/button";
@@ -34,14 +34,38 @@ const assetsFetcher = async (url: string) => {
   return data.message as ReleaseAssetSummary[];
 };
 
-function WpChart({ points, home, away }: { points: WpPoint[]; home: string; away: string }) {
+function WpChart({
+  points,
+  home,
+  away,
+  hoverI,
+  onHover,
+}: {
+  points: WpPoint[];
+  home: string;
+  away: string;
+  /** Linked hover: the play index highlighted in BOTH the chart and the log. */
+  hoverI: number | null;
+  onHover: (i: number | null) => void;
+}) {
   const W = 820;
   const H = 280;
   const pad = { l: 44, r: 12, t: 16, b: 24 };
   const n = points.length;
+  const svgRef = useRef<SVGSVGElement>(null);
   if (n < 2) return null;
   const x = (i: number) => pad.l + (i * (W - pad.l - pad.r)) / (n - 1);
   const y = (wp: number) => pad.t + (1 - wp) * (H - pad.t - pad.b);
+  /** Pointer x (client px) → nearest play index, via the live CTM so the
+   *  responsive viewBox scaling is accounted for. */
+  function indexFromEvent(e: React.MouseEvent<SVGSVGElement>): number {
+    const svg = svgRef.current;
+    if (!svg) return 0;
+    const rect = svg.getBoundingClientRect();
+    const vx = ((e.clientX - rect.left) / rect.width) * W;
+    const t = (vx - pad.l) / (W - pad.l - pad.r);
+    return Math.max(0, Math.min(n - 1, Math.round(t * (n - 1))));
+  }
   const line = points.map((p, i) => `${x(i).toFixed(1)},${y(p.wp).toFixed(1)}`).join(" ");
   // Period boundaries: first index of each period after the first.
   const boundaries: { i: number; period: number }[] = [];
@@ -49,7 +73,15 @@ function WpChart({ points, home, away }: { points: WpPoint[]; home: string; away
     if (points[i].period !== points[i - 1].period) boundaries.push({ i, period: points[i].period });
   }
   return (
-    <svg viewBox={`0 0 ${W} ${H}`} className="w-full" role="img" aria-label={`Win probability chart, ${away} at ${home}`}>
+    <svg
+      ref={svgRef}
+      viewBox={`0 0 ${W} ${H}`}
+      className="w-full"
+      role="img"
+      aria-label={`Win probability chart, ${away} at ${home}`}
+      onMouseMove={(e) => onHover(indexFromEvent(e))}
+      onMouseLeave={() => onHover(null)}
+    >
       {[0, 0.25, 0.5, 0.75, 1].map((tick) => (
         <g key={tick}>
           <line
@@ -85,6 +117,34 @@ function WpChart({ points, home, away }: { points: WpPoint[]; home: string; away
       <text x={pad.l} y={pad.t - 4} className="fill-current font-inter text-[11px] text-muted-foreground">
         {home} win probability
       </text>
+      {hoverI != null && points[hoverI] ? (
+        (() => {
+          const p = points[hoverI];
+          const hx = x(hoverI);
+          const hy = y(p.wp);
+          const boxW = 300;
+          const bx = Math.min(Math.max(hx + 10, pad.l), W - pad.r - boxW);
+          const above = hy > H / 2;
+          const by = above ? hy - 74 : hy + 12;
+          const play = p.text.length > 76 ? `${p.text.slice(0, 75)}…` : p.text;
+          return (
+            <g pointerEvents="none">
+              <line x1={hx} x2={hx} y1={pad.t} y2={H - pad.b} className="stroke-score" strokeWidth={1} />
+              <circle cx={hx} cy={hy} r={4} className="fill-score stroke-background" strokeWidth={1.5} />
+              <rect x={bx} y={by} width={boxW} height={62} rx={6} className="fill-popover stroke-border" strokeWidth={1} />
+              <text x={bx + 10} y={by + 17} className="fill-current font-inter text-[11px] font-semibold">
+                {p.period > 4 ? "OT" : `Q${p.period}`} {p.clock} · {p.score} · {(p.wp * 100).toFixed(1)}% {home}
+              </text>
+              <text x={bx + 10} y={by + 34} className="fill-current font-inter text-[10px] text-muted-foreground">
+                {play.slice(0, 48)}
+              </text>
+              <text x={bx + 10} y={by + 48} className="fill-current font-inter text-[10px] text-muted-foreground">
+                {play.slice(48)}
+              </text>
+            </g>
+          );
+        })()
+      ) : null}
     </svg>
   );
 }
@@ -97,6 +157,18 @@ export default function WpClient() {
   const [points, setPoints] = useState<WpPoint[]>([]);
   const [teams, setTeams] = useState<{ home: string; away: string }>({ home: "", away: "" });
   const [busy, setBusy] = useState<string | null>(null);
+  const [hoverI, setHoverI] = useState<number | null>(null);
+  const hoverFromChart = useRef(false);
+  const logRef = useRef<HTMLDivElement>(null);
+
+  // Chart-driven hovers scroll the play log to keep the highlighted row visible;
+  // table-driven hovers must NOT scroll-jack the user's own pointer.
+  useEffect(() => {
+    if (hoverI == null || !hoverFromChart.current) return;
+    logRef.current
+      ?.querySelector<HTMLElement>(`[data-play="${hoverI}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [hoverI]);
   const [error, setError] = useState<string | null>(null);
 
   const sport = useMemo(
@@ -263,10 +335,19 @@ export default function WpClient() {
       {points.length > 1 ? (
         <>
           <div className="mb-6 rounded-lg border border-border bg-card/70 p-4">
-            <WpChart points={points} home={teams.home} away={teams.away} />
+            <WpChart
+              points={points}
+              home={teams.home}
+              away={teams.away}
+              hoverI={hoverI}
+              onHover={(i) => {
+                hoverFromChart.current = true;
+                setHoverI(i);
+              }}
+            />
           </div>
           <h3 className="mb-2 font-barlow text-lg font-semibold">Play log</h3>
-          <div className="max-h-[28rem] overflow-auto rounded-lg border border-border">
+          <div ref={logRef} className="scrollbar-visible max-h-[28rem] max-w-full rounded-lg border border-border" onMouseLeave={() => setHoverI(null)}>
             <table className="w-full text-left font-inter text-sm">
               <thead className="sticky top-0 bg-muted text-xs uppercase text-muted-foreground">
                 <tr>
@@ -279,7 +360,17 @@ export default function WpClient() {
               </thead>
               <tbody>
                 {points.map((p, i) => (
-                  <tr key={i} className="border-t border-border">
+                  <tr
+                    key={i}
+                    data-play={i}
+                    onMouseEnter={() => {
+                      hoverFromChart.current = false;
+                      setHoverI(i);
+                    }}
+                    className={`border-t border-border transition-colors ${
+                      hoverI === i ? "bg-score/20" : "hover:bg-muted/60"
+                    }`}
+                  >
                     <td className="whitespace-nowrap px-3 py-1">{p.period > 4 ? "OT" : p.period}</td>
                     <td className="whitespace-nowrap px-3 py-1">{p.clock}</td>
                     <td className="whitespace-nowrap px-3 py-1">{p.score}</td>

--- a/frontend/components/platform/QueryBuilder.tsx
+++ b/frontend/components/platform/QueryBuilder.tsx
@@ -30,6 +30,7 @@ import {
 import { Skeleton } from "@components/ui/skeleton";
 import { cn } from "@lib/utils";
 import ResultsGrid from "@components/platform/ResultsGrid";
+import { columnTip, tableTip } from "@lib/platform/glossary";
 
 const OPERATORS = [
   { suffix: "", label: "=" },
@@ -108,6 +109,7 @@ export default function QueryBuilder({ schemas }: { schemas: string[] }) {
   const [table, setTable] = useState("");
   const [tableSearch, setTableSearch] = useState("");
   const [colSearch, setColSearch] = useState("");
+  const [dragChip, setDragChip] = useState<string | null>(null);
   const [filters, setFilters] = useState<Filter[]>([]);
   const [select, setSelect] = useState<string[]>([]);
   const [order, setOrder] = useState("");
@@ -239,6 +241,20 @@ export default function QueryBuilder({ schemas }: { schemas: string[] }) {
     );
   }
 
+  function dropChipOn(target: string) {
+    if (!dragChip || dragChip === target) return;
+    setSelect((s) => {
+      const src = s.indexOf(dragChip);
+      const dst = s.indexOf(target);
+      if (src < 0 || dst < 0) return s;
+      const next = [...s];
+      next.splice(src, 1);
+      next.splice(dst, 0, dragChip);
+      return next;
+    });
+    setDragChip(null);
+  }
+
   function moveSelected(name: string, delta: -1 | 1) {
     setSelect((s) => {
       const i = s.indexOf(name);
@@ -337,6 +353,7 @@ export default function QueryBuilder({ schemas }: { schemas: string[] }) {
                 <button
                   key={t}
                   type="button"
+                  title={tableTip(t)}
                   onClick={() => setTable(t)}
                   className={cn(
                     "rounded-md border px-2 py-0.5 font-mono text-[11px] transition-colors",
@@ -366,6 +383,7 @@ export default function QueryBuilder({ schemas }: { schemas: string[] }) {
                     <button
                       key={t}
                       type="button"
+                      title={columnTip(t, columnTypes[t])}
                       onClick={() => addTagFilter(t)}
                       className="rounded-full border border-dashed border-primary/50 px-2 py-0.5 font-mono text-[11px] text-primary hover:bg-primary/10"
                     >
@@ -488,16 +506,22 @@ export default function QueryBuilder({ schemas }: { schemas: string[] }) {
                     return (
                       <span
                         key={name}
+                        draggable={on}
+                        onDragStart={() => setDragChip(name)}
+                        onDragOver={(e) => on && e.preventDefault()}
+                        onDrop={() => dropChipOn(name)}
+                        onDragEnd={() => setDragChip(null)}
                         className={cn(
                           "inline-flex items-center overflow-hidden rounded-md border font-mono text-[11px]",
                           on
-                            ? "border-primary/60 bg-primary/15 text-primary"
-                            : "border-border/70 text-muted-foreground"
+                            ? "cursor-grab border-primary/60 bg-primary/15 text-primary active:cursor-grabbing"
+                            : "border-border/70 text-muted-foreground",
+                          dragChip === name && "opacity-40"
                         )}
                       >
                         <button
                           type="button"
-                          title={columnTypes[name]}
+                          title={columnTip(name, columnTypes[name])}
                           onClick={() =>
                             setSelect((s) =>
                               on ? s.filter((c) => c !== name) : [...s, name]

--- a/frontend/components/platform/ResultsGrid.tsx
+++ b/frontend/components/platform/ResultsGrid.tsx
@@ -1,28 +1,39 @@
 "use client";
 
-import { useMemo, useRef, useState } from "react";
-import { ArrowDown, ArrowUp, ListFilter, X } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ArrowDown, ArrowUp, GripVertical, ListFilter, X } from "lucide-react";
 import { cn } from "@lib/utils";
+import { columnTip } from "@lib/platform/glossary";
 
 /**
- * Keyboard-first results grid for the platform query surfaces.
+ * Keyboard-first results grid for the platform data surfaces.
  *
  * - Arrow keys / PageUp / PageDown / Home / End move a roving cell focus
- *   (Ctrl+Home/End jump to the corners), so a result set can be scanned
- *   without touching the mouse.
- * - Clicking a column header (or pressing `f` on any of its cells) opens a
- *   within-table filter for that column; `s` (or header re-click) cycles
- *   asc → desc → off sorting. Filtering and sorting are client-side over the
- *   already-fetched rows — the API round trip is untouched.
- * - `Escape` clears the active column filter, then focus.
+ *   (Ctrl+Home/End jump to the corners); clicking any cell selects and
+ *   highlights its WHOLE row (Escape clears).
+ * - A frozen `#` column keeps the original row number visible during
+ *   horizontal scroll (sticky on both axes at the header corner).
+ * - Column headers drag-and-drop to reorder the view; click a header (or
+ *   press `f` on a cell) for a within-table per-column filter; `s` cycles
+ *   asc → desc → off sorting. All client-side over the fetched rows.
+ * - Headers carry glossary tooltips (lib/platform/glossary).
+ * - `highlightIndex`/`onRowHover` link the grid to external visuals (e.g. a
+ *   win-probability chart): hovering the chart highlights + scrolls to the
+ *   row, hovering a row reports back its ORIGINAL index.
  */
 
 export type GridProps = {
   columns: string[];
   /** Row-major cells; null renders as ∅. */
   rows: (string | null)[][];
-  /** Optional dtype per column (shown in the header tooltip). */
+  /** Optional dtype per column (folded into the header tooltip). */
   types?: Record<string, string>;
+  /** Externally-driven row highlight (original row index), e.g. from a chart. */
+  highlightIndex?: number | null;
+  /** Fires with the ORIGINAL row index under the pointer (null on leave). */
+  onRowHover?: (index: number | null) => void;
+  /** Fires when a row is selected via click/focus. */
+  onRowSelect?: (index: number | null) => void;
 };
 
 type Sort = { col: number; dir: "asc" | "desc" } | null;
@@ -40,42 +51,87 @@ function compare(a: string | null, b: string | null): number {
   return a.localeCompare(b);
 }
 
-export default function ResultsGrid({ columns, rows, types }: GridProps) {
+export default function ResultsGrid({
+  columns,
+  rows,
+  types,
+  highlightIndex,
+  onRowHover,
+  onRowSelect,
+}: GridProps) {
   const [filters, setFilters] = useState<Record<number, string>>({});
   const [filterOpen, setFilterOpen] = useState<number | null>(null);
   const [sort, setSort] = useState<Sort>(null);
   const [focus, setFocus] = useState<{ r: number; c: number }>({ r: 0, c: 0 });
+  const [selectedRow, setSelectedRow] = useState<number | null>(null); // original index
+  /** View order of column indices — drag-and-drop permutes this. */
+  const [order, setOrder] = useState<number[]>([]);
+  const [dragCol, setDragCol] = useState<number | null>(null);
   const bodyRef = useRef<HTMLTableSectionElement>(null);
+  const scrollerRef = useRef<HTMLDivElement>(null);
   const filterInputRef = useRef<HTMLInputElement>(null);
 
+  useEffect(() => {
+    setOrder(columns.map((_, i) => i));
+    setFilters({});
+    setSort(null);
+    setSelectedRow(null);
+  }, [columns]);
+
+  const colOrder = order.length === columns.length ? order : columns.map((_, i) => i);
+
+  /** Filtered + sorted view; each row keeps its ORIGINAL index for numbering,
+   *  selection identity, and chart linking. */
   const view = useMemo(() => {
-    let out = rows;
+    let out = rows.map((cells, orig) => ({ cells, orig }));
     const active = Object.entries(filters).filter(([, v]) => v !== "");
     if (active.length) {
-      out = out.filter((row) =>
+      out = out.filter(({ cells }) =>
         active.every(([c, v]) =>
-          (row[Number(c)] ?? "").toLowerCase().includes(v.toLowerCase())
+          (cells[Number(c)] ?? "").toLowerCase().includes(v.toLowerCase())
         )
       );
     }
     if (sort) {
       out = [...out].sort(
-        (a, b) => compare(a[sort.col], b[sort.col]) * (sort.dir === "asc" ? 1 : -1)
+        (a, b) =>
+          compare(a.cells[sort.col], b.cells[sort.col]) * (sort.dir === "asc" ? 1 : -1)
       );
     }
     return out;
   }, [rows, filters, sort]);
 
+  const viewIndexByOrig = useMemo(() => {
+    const m = new Map<number, number>();
+    view.forEach((v, i) => m.set(v.orig, i));
+    return m;
+  }, [view]);
+
+  // Externally-driven highlight (chart hover): scroll the row into view.
+  useEffect(() => {
+    if (highlightIndex == null) return;
+    const vi = viewIndexByOrig.get(highlightIndex);
+    if (vi == null) return;
+    bodyRef.current
+      ?.querySelector<HTMLElement>(`[data-row="${vi}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [highlightIndex, viewIndexByOrig]);
+
   function focusCell(r: number, c: number) {
     const nr = Math.max(0, Math.min(view.length - 1, r));
-    const nc = Math.max(0, Math.min(columns.length - 1, c));
+    const nc = Math.max(0, Math.min(colOrder.length - 1, c));
     setFocus({ r: nr, c: nc });
-    // Roving tabindex: the cell is rendered focusable; find and focus it.
     requestAnimationFrame(() => {
       bodyRef.current
         ?.querySelector<HTMLElement>(`[data-cell="${nr}-${nc}"]`)
         ?.focus();
     });
+  }
+
+  function selectRow(viewRow: number | null) {
+    const orig = viewRow == null ? null : (view[viewRow]?.orig ?? null);
+    setSelectedRow(orig);
+    onRowSelect?.(orig);
   }
 
   function onCellKeyDown(e: React.KeyboardEvent, r: number, c: number) {
@@ -89,32 +145,37 @@ export default function ResultsGrid({ columns, rows, types }: GridProps) {
     };
     if (e.key in nav) {
       e.preventDefault();
-      focusCell(...nav[e.key]);
+      const [nr, nc] = nav[e.key];
+      focusCell(nr, nc);
+      selectRow(Math.max(0, Math.min(view.length - 1, nr)));
       return;
     }
     if (e.key === "Home") {
       e.preventDefault();
-      focusCell(e.ctrlKey ? 0 : r, e.ctrlKey ? 0 : 0);
+      focusCell(e.ctrlKey ? 0 : r, 0);
+      if (e.ctrlKey) selectRow(0);
       return;
     }
     if (e.key === "End") {
       e.preventDefault();
-      focusCell(e.ctrlKey ? view.length - 1 : r, columns.length - 1);
+      focusCell(e.ctrlKey ? view.length - 1 : r, colOrder.length - 1);
+      if (e.ctrlKey) selectRow(view.length - 1);
       return;
     }
     if (e.key === "f") {
       e.preventDefault();
-      setFilterOpen(c);
+      setFilterOpen(colOrder[c]);
       requestAnimationFrame(() => filterInputRef.current?.focus());
       return;
     }
     if (e.key === "s") {
       e.preventDefault();
-      cycleSort(c);
+      cycleSort(colOrder[c]);
       return;
     }
     if (e.key === "Escape") {
-      if (filters[c]) setFilters((f) => ({ ...f, [c]: "" }));
+      if (filters[colOrder[c]]) setFilters((f) => ({ ...f, [colOrder[c]]: "" }));
+      else if (selectedRow != null) selectRow(null);
       else (e.target as HTMLElement).blur();
     }
   }
@@ -134,10 +195,24 @@ export default function ResultsGrid({ columns, rows, types }: GridProps) {
     }
   }
 
+  function dropOn(target: number) {
+    if (dragCol == null || dragCol === target) return;
+    setOrder((o) => {
+      const src = o.indexOf(dragCol);
+      const dst = o.indexOf(target);
+      if (src < 0 || dst < 0) return o;
+      const next = [...o];
+      next.splice(src, 1);
+      next.splice(dst, 0, dragCol);
+      return next;
+    });
+    setDragCol(null);
+  }
+
   const activeFilters = Object.entries(filters).filter(([, v]) => v !== "");
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex min-w-0 flex-col gap-2">
       <div className="flex flex-wrap items-center gap-2 font-mono text-xs text-muted-foreground">
         <span>
           {view.length.toLocaleString("en-US")} of {rows.length.toLocaleString("en-US")} rows
@@ -157,82 +232,131 @@ export default function ResultsGrid({ columns, rows, types }: GridProps) {
           </span>
         ))}
         <span className="ml-auto hidden text-[10px] sm:inline">
-          arrows navigate · click header or <kbd>f</kbd> filters · <kbd>s</kbd> sorts
+          arrows navigate · click selects row · drag headers to reorder · <kbd>f</kbd> filters ·{" "}
+          <kbd>s</kbd> sorts
         </span>
       </div>
 
-      <div className="max-h-[32rem] overflow-auto rounded-lg border border-border/60">
+      <div
+        ref={scrollerRef}
+        className="scrollbar-visible max-h-[32rem] max-w-full rounded-lg border border-border/60"
+        onMouseLeave={() => onRowHover?.(null)}
+      >
         <table role="grid" className="w-full text-left font-mono text-xs">
-          <thead className="sticky top-0 z-10 bg-muted">
+          <thead className="sticky top-0 z-20 bg-muted">
             <tr>
-              {columns.map((name, c) => (
-                <th key={name} className="whitespace-nowrap px-0 py-0 align-top">
-                  <button
-                    type="button"
-                    onClick={() => headerClick(c)}
-                    title={types?.[name] ? `${name} (${types[name]})` : name}
+              <th className="sticky left-0 z-30 w-10 whitespace-nowrap bg-muted px-2 py-2 text-right uppercase text-muted-foreground">
+                #
+              </th>
+              {colOrder.map((ci) => {
+                const name = columns[ci];
+                return (
+                  <th
+                    key={name}
+                    draggable
+                    onDragStart={() => setDragCol(ci)}
+                    onDragOver={(e) => e.preventDefault()}
+                    onDrop={() => dropOn(ci)}
+                    onDragEnd={() => setDragCol(null)}
                     className={cn(
-                      "flex w-full items-center gap-1 px-3 py-2 uppercase text-muted-foreground hover:text-foreground",
-                      (sort?.col === c || filters[c]) && "text-primary"
+                      "whitespace-nowrap px-0 py-0 align-top",
+                      dragCol === ci && "opacity-40"
                     )}
                   >
-                    {name}
-                    {sort?.col === c ? (
-                      sort.dir === "asc" ? (
-                        <ArrowUp className="size-3" />
-                      ) : (
-                        <ArrowDown className="size-3" />
-                      )
-                    ) : null}
-                    {filters[c] ? <ListFilter className="size-3" /> : null}
-                  </button>
-                  {filterOpen === c ? (
-                    <div className="px-2 pb-2">
-                      <input
-                        ref={filterInputRef}
-                        value={filters[c] ?? ""}
-                        placeholder={`filter ${name}…`}
-                        onChange={(e) =>
-                          setFilters((f) => ({ ...f, [c]: e.target.value }))
-                        }
-                        onKeyDown={(e) => {
-                          if (e.key === "Escape" || e.key === "Enter") {
-                            if (e.key === "Escape")
-                              setFilters((f) => ({ ...f, [c]: "" }));
-                            setFilterOpen(null);
-                            focusCell(0, c);
+                    <button
+                      type="button"
+                      onClick={() => headerClick(ci)}
+                      title={columnTip(name, types?.[name])}
+                      className={cn(
+                        "flex w-full cursor-grab items-center gap-1 px-3 py-2 uppercase text-muted-foreground hover:text-foreground active:cursor-grabbing",
+                        (sort?.col === ci || filters[ci]) && "text-primary"
+                      )}
+                    >
+                      <GripVertical className="size-3 opacity-40" />
+                      {name}
+                      {sort?.col === ci ? (
+                        sort.dir === "asc" ? (
+                          <ArrowUp className="size-3" />
+                        ) : (
+                          <ArrowDown className="size-3" />
+                        )
+                      ) : null}
+                      {filters[ci] ? <ListFilter className="size-3" /> : null}
+                    </button>
+                    {filterOpen === ci ? (
+                      <div className="px-2 pb-2">
+                        <input
+                          ref={filterInputRef}
+                          value={filters[ci] ?? ""}
+                          placeholder={`filter ${name}…`}
+                          onChange={(e) =>
+                            setFilters((f) => ({ ...f, [ci]: e.target.value }))
                           }
-                        }}
-                        onBlur={() => setFilterOpen(null)}
-                        className="w-full rounded border border-input bg-card px-2 py-1 font-mono text-[11px] normal-case text-foreground"
-                      />
-                    </div>
-                  ) : null}
-                </th>
-              ))}
+                          onKeyDown={(e) => {
+                            if (e.key === "Escape" || e.key === "Enter") {
+                              if (e.key === "Escape")
+                                setFilters((f) => ({ ...f, [ci]: "" }));
+                              setFilterOpen(null);
+                            }
+                          }}
+                          onBlur={() => setFilterOpen(null)}
+                          className="w-full rounded border border-input bg-card px-2 py-1 font-mono text-[11px] normal-case text-foreground"
+                        />
+                      </div>
+                    ) : null}
+                  </th>
+                );
+              })}
             </tr>
           </thead>
           <tbody ref={bodyRef}>
-            {view.map((row, r) => (
-              <tr key={r} className="border-t border-border/60">
-                {row.map((cell, c) => (
+            {view.map(({ cells, orig }, r) => {
+              const isSelected = selectedRow === orig;
+              const isLinked = highlightIndex === orig;
+              return (
+                <tr
+                  key={orig}
+                  data-row={r}
+                  onMouseEnter={() => onRowHover?.(orig)}
+                  className={cn(
+                    "border-t border-border/60 transition-colors",
+                    isSelected && "bg-primary/15",
+                    isLinked && !isSelected && "bg-score/15",
+                    !isSelected && !isLinked && "hover:bg-muted/60"
+                  )}
+                >
                   <td
-                    key={c}
-                    data-cell={`${r}-${c}`}
-                    tabIndex={focus.r === r && focus.c === c ? 0 : -1}
-                    onKeyDown={(e) => onCellKeyDown(e, r, c)}
-                    onFocus={() => setFocus({ r, c })}
-                    title={cell ?? ""}
                     className={cn(
-                      "max-w-64 truncate whitespace-nowrap px-3 py-1 outline-none",
-                      "focus:bg-primary/15 focus:ring-1 focus:ring-inset focus:ring-primary"
+                      "sticky left-0 z-10 w-10 whitespace-nowrap px-2 py-1 text-right text-muted-foreground",
+                      isSelected
+                        ? "bg-primary/15"
+                        : isLinked
+                          ? "bg-score/15"
+                          : "bg-card"
                     )}
                   >
-                    {cell === null ? "∅" : cell}
+                    {orig + 1}
                   </td>
-                ))}
-              </tr>
-            ))}
+                  {colOrder.map((ci, c) => (
+                    <td
+                      key={ci}
+                      data-cell={`${r}-${c}`}
+                      tabIndex={focus.r === r && focus.c === c ? 0 : -1}
+                      onKeyDown={(e) => onCellKeyDown(e, r, c)}
+                      onFocus={() => setFocus({ r, c })}
+                      onClick={() => selectRow(isSelected ? null : r)}
+                      title={cells[ci] ?? ""}
+                      className={cn(
+                        "max-w-64 truncate whitespace-nowrap px-3 py-1 outline-none",
+                        "focus:ring-1 focus:ring-inset focus:ring-primary"
+                      )}
+                    >
+                      {cells[ci] === null ? "∅" : cells[ci]}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
           </tbody>
         </table>
         {view.length === 0 ? (

--- a/frontend/lib/platform/glossary.ts
+++ b/frontend/lib/platform/glossary.ts
@@ -1,0 +1,131 @@
+/**
+ * Hover glossary for the platform data surfaces.
+ *
+ * Curated descriptions for the column names and tables that recur across the
+ * warehouse (mirrors the sdv-py returns-table language). Lookup is by bare
+ * column name with a dtype fallback, so every tooltip shows *something* and
+ * known names show a real definition. Extend freely — one entry here surfaces
+ * everywhere (grid headers, column chips, filter selects).
+ */
+
+export const COLUMN_GLOSSARY: Record<string, string> = {
+  // identity / keys
+  season: "Season, keyed by the 4-digit ending year (2024 = the 2023-24 cross-year season).",
+  season_type: "Regular season vs postseason indicator (provider-coded).",
+  week: "Week number within the season.",
+  game_id: "Unique game identifier (provider-native; join key across game tables).",
+  game_date: "Calendar date the game was played.",
+  team_id: "Unique team identifier — the join key to team/roster tables.",
+  athlete_id: "Unique player identifier (ESPN athlete id).",
+  player_id: "Unique player identifier (stats-provider person id).",
+  play_id: "Unique play identifier within a game.",
+  drive_id: "Unique drive identifier (football) — groups plays into possessions.",
+  pos_team: "The team in possession on this row (offense).",
+  def_pos_team: "The team defending on this row.",
+  posteam: "Offense (possession team) — nflverse naming.",
+  defteam: "Defense — nflverse naming.",
+  home_team: "Home team name/abbreviation.",
+  away_team: "Away team name/abbreviation.",
+  conference: "Conference the team belongs to.",
+  division: "Division/level (e.g. FBS) or divisional grouping.",
+
+  // core advanced metrics
+  epa: "Expected Points Added — change in expected points from before to after the play.",
+  wpa: "Win Probability Added — change in win probability attributable to the play.",
+  wp: "Pre-play win probability for the possession/home team (model output, 0-1).",
+  home_wp: "Home team's win probability at this point in the game (0-1).",
+  vegas_wp: "Win probability from the spread-informed model.",
+  success: "Success indicator — whether the play beat the efficiency baseline (EPA > 0).",
+  explosiveness: "Average EPA on successful plays — how big the wins are when they win.",
+  havoc: "Havoc rate — share of plays with a TFL, forced fumble, pass breakup, or INT.",
+  adj_off_epa: "Opponent-adjusted offensive EPA per play (ridge-adjusted for schedule).",
+  adj_def_epa: "Opponent-adjusted defensive EPA per play allowed — negative is better.",
+  adj_st_epa: "Opponent-adjusted special-teams EPA per play.",
+  adj_net: "Net adjusted EPA per play: adj_off_epa − adj_def_epa. The single-number team rating.",
+  net_adj_epa: "Net adjusted EPA per play: adjusted offense minus adjusted defense.",
+  fei_net: "FEI-style net efficiency rating (possession-based, opponent-adjusted).",
+  off_rank: "Rank of adjusted offensive EPA within the season (1 = best).",
+  def_rank: "Rank of adjusted defensive EPA within the season (1 = best).",
+  net_rank: "Rank of net adjusted EPA within the season (1 = best).",
+  net_z: "Net adjusted EPA expressed as a z-score against the season's distribution.",
+  pctile: "Percentile bucket (0-100) this row's distribution values describe.",
+
+  // play-by-play context
+  period: "Period/quarter number (values above 4 are overtime).",
+  clock: "Game clock display at the snap/event.",
+  down: "Down (football).",
+  distance: "Yards to gain for a first down.",
+  yards_gained: "Yards gained on the play.",
+  yard_line: "Field position at the snap.",
+  play_type: "Provider-coded play type (rush, pass, kickoff, ...).",
+  play_text: "Narrative description of the play.",
+  text: "Narrative description of the play/event.",
+  score_differential: "Possession team score minus opponent score before the play.",
+  home_score: "Home team score after/at the row's event.",
+  away_score: "Away team score after/at the row's event.",
+
+  // box / season stats
+  min: "Minutes played.",
+  pts: "Points.",
+  reb: "Total rebounds.",
+  ast: "Assists.",
+  stl: "Steals.",
+  blk: "Blocks.",
+  tov: "Turnovers.",
+  fg_pct: "Field-goal percentage.",
+  fg3_pct: "Three-point percentage.",
+  ft_pct: "Free-throw percentage.",
+  plus_minus: "Team point differential while the player was on the floor.",
+  num: "Jersey number worn by the player.",
+  exp: "Years of playing experience entering the season ('R' = rookie).",
+
+  // roster / people
+  full_name: "Player full display name.",
+  position: "Listed position.",
+  height: "Listed height.",
+  weight: "Listed weight (lbs).",
+  birth_date: "Date of birth.",
+  headshot_url: "URL of the player's headshot image.",
+};
+
+/** Table-level blurbs, keyed by bare table name (schema-agnostic). */
+export const TABLE_GLOSSARY: Record<string, string> = {
+  pbp: "Play-by-play — one row per play/event with model enrichment (EPA/WP where available).",
+  schedule: "One row per game: matchup, date, venue, scores, status.",
+  team_box: "Team box scores — one row per team per game.",
+  player_box: "Player box scores — one row per player per game.",
+  rosters: "Season rosters — one row per player per team-season.",
+  game_rosters: "Game-level rosters — who was on the roster for each game.",
+  standings: "Season standings snapshots.",
+  shots: "Shot-level detail with coordinates where the provider ships them.",
+  ratings: "Opponent-adjusted team ratings — one row per team-season (adj EPA, FEI, ranks).",
+  team_summaries: "The wide team-season profile: adjusted EPA, success/explosiveness splits, situational rates.",
+  percentiles: "Season distribution percentiles for the summary metrics (one row per percentile).",
+  betting: "Closing/consensus betting lines per game.",
+  drives: "Drive-level summaries (football).",
+  model_pbp: "Model-scored play-by-play from the in-house EPA/WP models.",
+  player_impact: "Player impact/on-off value model output.",
+  lineups: "Lineup-level (multi-player unit) stats.",
+  player_game_logs: "One row per player per game — the stats-provider game log.",
+  player_season_stats: "Player season aggregates.",
+  team_season_stats: "Team season aggregates.",
+  officials: "Game officials assignments.",
+  coaches: "Coach records per team-season.",
+  schedule_crosswalk: "Id-mapping between providers for games.",
+  player_crosswalk: "Id-mapping between providers for players.",
+  team_crosswalk: "Id-mapping between providers for teams.",
+  fpi_weekly: "ESPN FPI weekly snapshots.",
+};
+
+/** Tooltip text for a column: glossary hit + dtype, or dtype alone. */
+export function columnTip(name: string, dtype?: string): string {
+  const desc = COLUMN_GLOSSARY[name];
+  const type = dtype ? ` (${dtype})` : "";
+  return desc ? `${name}${type} — ${desc}` : `${name}${type}`;
+}
+
+/** Tooltip text for a table chip. */
+export function tableTip(name: string): string {
+  const desc = TABLE_GLOSSARY[name];
+  return desc ? `${name} — ${desc}` : name;
+}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -80,6 +80,24 @@
 @utility font-barlow { font-family: var(--font-barlow), var(--font-inter), sans-serif; }
 @utility font-sarina { font-family: var(--font-sarina), cursive; }
 
+/* Always-visible, thin scrollbars for data-dense scroll containers (results
+   grids, play logs) so both axes are discoverable without hover-hunting. */
+@utility scrollbar-visible {
+  overflow: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+  scrollbar-gutter: stable;
+  &::-webkit-scrollbar { width: 10px; height: 10px; }
+  &::-webkit-scrollbar-track { background: transparent; }
+  &::-webkit-scrollbar-thumb {
+    background: var(--border);
+    border-radius: 5px;
+    border: 2px solid transparent;
+    background-clip: content-box;
+  }
+  &::-webkit-scrollbar-thumb:hover { background-color: var(--muted-foreground); }
+}
+
 /* Broadcast eyebrow: the small label above headlines and section heads. */
 @utility eyebrow {
   font-family: var(--font-mono);


### PR DESCRIPTION
Six UX upgrades across the platform data surfaces:

1. **Whole-row selection** — click or keyboard-navigate any grid row to highlight it full-width; selection keys on the *original* row index so it survives sorting/filtering.
2. **Drag-and-drop ordering** — grid headers reorder the view live; selected column chips drag to reorder, which reorders the API `select=` itself.
3. **Hover glossary** — new `lib/platform/glossary.ts` (~80 columns, ~25 tables, mirroring sdv-py returns-table language) as tooltips on headers, chips, and filter tags with dtypes folded in.
4. **Frozen row numbers** — sticky `#` column pins through horizontal scroll (two-axis sticky corner).
5. **Visible scrollbars** — `scrollbar-visible` utility (thin, always-on, stable gutter) on the grid and play log; `max-w-full` keeps both axes inside the container.
6. **Linked chart↔table hover** on `/platform/wp` — chart hover shows crosshair + amber dot + tooltip (period/clock/score/WP% + play text) and highlights/auto-scrolls the play-log row; log hover lights the chart point; a source flag prevents scroll-jacking. `ResultsGrid` exposes the pattern generically (`highlightIndex`/`onRowHover`/`onRowSelect`) for reuse across SDV apps (game-on-paper etc.).

`tsc` + `eslint` + `next build` green.

## Summary by Sourcery

Enhance platform data surfaces with richer grid interaction, glossary tooltips, and linked chart–table hover on win probability views.

New Features:
- Add whole-row selection and externally-driven row highlighting to ResultsGrid, including callbacks for hover and selection.
- Enable drag-and-drop reordering of grid columns and query builder select chips to control view order and API select ordering.
- Introduce a hover-linked win probability chart and play log that synchronize highlighted plays and scrolling between the two surfaces.
- Provide a centralized platform glossary for common columns and tables, surfacing as tooltips on grid headers, column chips, and table tags.

Enhancements:
- Add frozen row-number column, visible scrollbars, and min-width handling to improve usability of dense results grids and play logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Synchronized hover highlighting between win-probability charts and play logs, including automatic navigation to matching plays.
  * Added glossary tooltips for tables, columns, and data types.
  * Added drag-and-drop column reordering in query building and result tables.
  * Added row selection, keyboard navigation, highlighting, and a frozen row-number column to results grids.
  * Added improved scrolling controls for data-heavy views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->