### PR TITLE
feat(platform): value-encoded data grid — heat cells, condensed numerals, hotkeys

### DIFF
--- a/frontend/components/platform/ResultsGrid.tsx
+++ b/frontend/components/platform/ResultsGrid.tsx
@@ -1,25 +1,35 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { ArrowDown, ArrowUp, GripVertical, ListFilter, X } from "lucide-react";
+import { ArrowDown, ArrowUp, Flame, GripVertical, ListFilter, X } from "lucide-react";
 import { cn } from "@lib/utils";
 import { columnTip } from "@lib/platform/glossary";
+import { cellTint, columnDomain, type Domain } from "@lib/platform/scales";
 
 /**
  * Keyboard-first results grid for the platform data surfaces.
  *
- * - Arrow keys / PageUp / PageDown / Home / End move a roving cell focus
- *   (Ctrl+Home/End jump to the corners); clicking any cell selects and
- *   highlights its WHOLE row (Escape clears).
- * - A frozen `#` column keeps the original row number visible during
- *   horizontal scroll (sticky on both axes at the header corner).
- * - Column headers drag-and-drop to reorder the view; click a header (or
- *   press `f` on a cell) for a within-table per-column filter; `s` cycles
- *   asc → desc → off sorting. All client-side over the fetched rows.
- * - Headers carry glossary tooltips (lib/platform/glossary).
- * - `highlightIndex`/`onRowHover` link the grid to external visuals (e.g. a
- *   win-probability chart): hovering the chart highlights + scrolls to the
- *   row, hovering a row reports back its ORIGINAL index.
+ * Reading model
+ * - Numeric cells carry a **bucketed diverging tint** measuring distance from
+ *   the column's baseline (zero for signed metrics, the median otherwise), so a
+ *   dense table reads as a heatmap before you read a single number. Toggle with
+ *   `h` when the shading is in the way.
+ * - Numerals are set in the condensed display face with `tabular-nums`, which
+ *   is what lets columns stay narrow enough to scan many at once.
+ *
+ * Navigation
+ * - Arrows / PageUp / PageDown / Home / End move a roving cell focus
+ *   (Ctrl+Home/End jump to the corners); clicking a cell selects and highlights
+ *   its whole row. A frozen `#` column keeps the original row number visible
+ *   through horizontal scroll.
+ * - `f` filters the focused column, `s` cycles its sort, `a`/`d` scroll
+ *   horizontally by a viewport, `w`/`e` change row density, `h` toggles heat.
+ *   The sticky status bar carries the legend so none of it is hidden knowledge.
+ *
+ * Linking
+ * - `highlightIndex`/`onRowHover`/`onRowSelect` connect the grid to external
+ *   visuals (a win-probability chart, a scatter) by ORIGINAL row index, so the
+ *   link survives sorting and filtering.
  */
 
 export type GridProps = {
@@ -32,16 +42,17 @@ export type GridProps = {
   highlightIndex?: number | null;
   /** Fires with the ORIGINAL row index under the pointer (null on leave). */
   onRowHover?: (index: number | null) => void;
-  /** Fires when a row is selected via click/focus. */
+  /** Fires when a row is selected via click/keyboard. */
   onRowSelect?: (index: number | null) => void;
 };
 
 type Sort = { col: number; dir: "asc" | "desc" } | null;
 
 const PAGE = 20;
+const DENSITY = ["py-0.5", "py-1", "py-2"] as const;
 
 function compare(a: string | null, b: string | null): number {
-  if (a === null) return b === null ? 0 : 1; // nulls last
+  if (a === null) return b === null ? 0 : 1; // nulls sink, both directions
   if (b === null) return -1;
   const na = Number(a);
   const nb = Number(b);
@@ -64,9 +75,10 @@ export default function ResultsGrid({
   const [sort, setSort] = useState<Sort>(null);
   const [focus, setFocus] = useState<{ r: number; c: number }>({ r: 0, c: 0 });
   const [selectedRow, setSelectedRow] = useState<number | null>(null); // original index
-  /** View order of column indices — drag-and-drop permutes this. */
   const [order, setOrder] = useState<number[]>([]);
   const [dragCol, setDragCol] = useState<number | null>(null);
+  const [heat, setHeat] = useState(true);
+  const [density, setDensity] = useState(1);
   const bodyRef = useRef<HTMLTableSectionElement>(null);
   const scrollerRef = useRef<HTMLDivElement>(null);
   const filterInputRef = useRef<HTMLInputElement>(null);
@@ -80,8 +92,14 @@ export default function ResultsGrid({
 
   const colOrder = order.length === columns.length ? order : columns.map((_, i) => i);
 
-  /** Filtered + sorted view; each row keeps its ORIGINAL index for numbering,
-   *  selection identity, and chart linking. */
+  /** One encoding domain per column, computed once over the full result. */
+  const domains = useMemo<(Domain | null)[]>(
+    () => columns.map((name, c) => columnDomain(rows.map((r) => r[c]), name)),
+    [columns, rows]
+  );
+
+  /** Filtered + sorted view; every row keeps its ORIGINAL index for numbering,
+   *  selection identity, and external linking. */
   const view = useMemo(() => {
     let out = rows.map((cells, orig) => ({ cells, orig }));
     const active = Object.entries(filters).filter(([, v]) => v !== "");
@@ -107,7 +125,7 @@ export default function ResultsGrid({
     return m;
   }, [view]);
 
-  // Externally-driven highlight (chart hover): scroll the row into view.
+  // Externally-driven highlight (chart hover): bring the row into view.
   useEffect(() => {
     if (highlightIndex == null) return;
     const vi = viewIndexByOrig.get(highlightIndex);
@@ -122,9 +140,7 @@ export default function ResultsGrid({
     const nc = Math.max(0, Math.min(colOrder.length - 1, c));
     setFocus({ r: nr, c: nc });
     requestAnimationFrame(() => {
-      bodyRef.current
-        ?.querySelector<HTMLElement>(`[data-cell="${nr}-${nc}"]`)
-        ?.focus();
+      bodyRef.current?.querySelector<HTMLElement>(`[data-cell="${nr}-${nc}"]`)?.focus();
     });
   }
 
@@ -132,6 +148,11 @@ export default function ResultsGrid({
     const orig = viewRow == null ? null : (view[viewRow]?.orig ?? null);
     setSelectedRow(orig);
     onRowSelect?.(orig);
+  }
+
+  function scrollByViewport(dir: -1 | 1) {
+    const el = scrollerRef.current;
+    if (el) el.scrollBy({ left: dir * el.clientWidth * 0.8, behavior: "smooth" });
   }
 
   function onCellKeyDown(e: React.KeyboardEvent, r: number, c: number) {
@@ -150,27 +171,39 @@ export default function ResultsGrid({
       selectRow(Math.max(0, Math.min(view.length - 1, nr)));
       return;
     }
-    if (e.key === "Home") {
+    if (e.key === "Home" || e.key === "End") {
       e.preventDefault();
-      focusCell(e.ctrlKey ? 0 : r, 0);
-      if (e.ctrlKey) selectRow(0);
+      const toRow = e.key === "Home" ? 0 : view.length - 1;
+      const toCol = e.key === "Home" ? 0 : colOrder.length - 1;
+      focusCell(e.ctrlKey ? toRow : r, toCol);
+      if (e.ctrlKey) selectRow(toRow);
       return;
     }
-    if (e.key === "End") {
-      e.preventDefault();
-      focusCell(e.ctrlKey ? view.length - 1 : r, colOrder.length - 1);
-      if (e.ctrlKey) selectRow(view.length - 1);
-      return;
-    }
-    if (e.key === "f") {
+    const key = e.key.toLowerCase();
+    if (key === "f") {
       e.preventDefault();
       setFilterOpen(colOrder[c]);
       requestAnimationFrame(() => filterInputRef.current?.focus());
       return;
     }
-    if (e.key === "s") {
+    if (key === "s") {
       e.preventDefault();
       cycleSort(colOrder[c]);
+      return;
+    }
+    if (key === "a" || key === "d") {
+      e.preventDefault();
+      scrollByViewport(key === "a" ? -1 : 1);
+      return;
+    }
+    if (key === "h") {
+      e.preventDefault();
+      setHeat((v) => !v);
+      return;
+    }
+    if (key === "w" || key === "e") {
+      e.preventDefault();
+      setDensity((d) => Math.max(0, Math.min(DENSITY.length - 1, d + (key === "e" ? 1 : -1))));
       return;
     }
     if (e.key === "Escape") {
@@ -187,9 +220,8 @@ export default function ResultsGrid({
   }
 
   function headerClick(c: number) {
-    if (filterOpen === c) {
-      cycleSort(c);
-    } else {
+    if (filterOpen === c) cycleSort(c);
+    else {
       setFilterOpen(c);
       requestAnimationFrame(() => filterInputRef.current?.focus());
     }
@@ -210,46 +242,45 @@ export default function ResultsGrid({
   }
 
   const activeFilters = Object.entries(filters).filter(([, v]) => v !== "");
+  const pad = DENSITY[density];
 
   return (
-    <div className="flex min-w-0 flex-col gap-2">
-      <div className="flex flex-wrap items-center gap-2 font-mono text-xs text-muted-foreground">
-        <span>
-          {view.length.toLocaleString("en-US")} of {rows.length.toLocaleString("en-US")} rows
-        </span>
-        {activeFilters.map(([c, v]) => (
-          <span
-            key={c}
-            className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-primary"
-          >
-            {columns[Number(c)]} ~ “{v}”
-            <button
-              aria-label={`clear ${columns[Number(c)]} filter`}
-              onClick={() => setFilters((f) => ({ ...f, [Number(c)]: "" }))}
+    <div className="flex min-w-0 flex-col">
+      {activeFilters.length ? (
+        <div className="mb-2 flex flex-wrap items-center gap-2 font-mono text-xs">
+          {activeFilters.map(([c, v]) => (
+            <span
+              key={c}
+              className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-primary"
             >
-              <X className="size-3" />
-            </button>
-          </span>
-        ))}
-        <span className="ml-auto hidden text-[10px] sm:inline">
-          arrows navigate · click selects row · drag headers to reorder · <kbd>f</kbd> filters ·{" "}
-          <kbd>s</kbd> sorts
-        </span>
-      </div>
+              {columns[Number(c)]} ~ “{v}”
+              <button
+                aria-label={`clear ${columns[Number(c)]} filter`}
+                onClick={() => setFilters((f) => ({ ...f, [Number(c)]: "" }))}
+              >
+                <X className="size-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+      ) : null}
 
       <div
         ref={scrollerRef}
-        className="scrollbar-visible max-h-[32rem] max-w-full rounded-lg border border-border/60"
+        className="scrollbar-visible max-h-[32rem] max-w-full rounded-t-lg border border-border/60"
         onMouseLeave={() => onRowHover?.(null)}
       >
-        <table role="grid" className="w-full text-left font-mono text-xs">
-          <thead className="sticky top-0 z-20 bg-muted">
+        {/* border-separate keeps cell borders painted under sticky headers,
+            which border-collapse drops. */}
+        <table role="grid" className="w-max min-w-full border-separate border-spacing-0 text-left text-xs">
+          <thead className="sticky top-0 z-20">
             <tr>
-              <th className="sticky left-0 z-30 w-10 whitespace-nowrap bg-muted px-2 py-2 text-right uppercase text-muted-foreground">
+              <th className="sticky left-0 z-30 border-b border-border/60 bg-muted px-2 py-2 text-right font-mono uppercase text-muted-foreground">
                 #
               </th>
               {colOrder.map((ci) => {
                 const name = columns[ci];
+                const encoded = heat && domains[ci] !== null;
                 return (
                   <th
                     key={name}
@@ -259,7 +290,8 @@ export default function ResultsGrid({
                     onDrop={() => dropOn(ci)}
                     onDragEnd={() => setDragCol(null)}
                     className={cn(
-                      "whitespace-nowrap px-0 py-0 align-top",
+                      "whitespace-nowrap border-b border-border/60 bg-muted p-0 align-top",
+                      sort?.col === ci && "bg-primary/10",
                       dragCol === ci && "opacity-40"
                     )}
                   >
@@ -268,12 +300,15 @@ export default function ResultsGrid({
                       onClick={() => headerClick(ci)}
                       title={columnTip(name, types?.[name])}
                       className={cn(
-                        "flex w-full cursor-grab items-center gap-1 px-3 py-2 uppercase text-muted-foreground hover:text-foreground active:cursor-grabbing",
+                        "flex w-full cursor-grab items-center gap-1 px-3 py-2 font-mono uppercase text-muted-foreground hover:text-foreground active:cursor-grabbing",
                         (sort?.col === ci || filters[ci]) && "text-primary"
                       )}
                     >
-                      <GripVertical className="size-3 opacity-40" />
+                      <GripVertical className="size-3 opacity-30" />
                       {name}
+                      {encoded ? (
+                        <Flame className="size-2.5 opacity-40" aria-label="value-encoded" />
+                      ) : null}
                       {sort?.col === ci ? (
                         sort.dir === "asc" ? (
                           <ArrowUp className="size-3" />
@@ -289,13 +324,10 @@ export default function ResultsGrid({
                           ref={filterInputRef}
                           value={filters[ci] ?? ""}
                           placeholder={`filter ${name}…`}
-                          onChange={(e) =>
-                            setFilters((f) => ({ ...f, [ci]: e.target.value }))
-                          }
+                          onChange={(e) => setFilters((f) => ({ ...f, [ci]: e.target.value }))}
                           onKeyDown={(e) => {
                             if (e.key === "Escape" || e.key === "Enter") {
-                              if (e.key === "Escape")
-                                setFilters((f) => ({ ...f, [ci]: "" }));
+                              if (e.key === "Escape") setFilters((f) => ({ ...f, [ci]: "" }));
                               setFilterOpen(null);
                             }
                           }}
@@ -313,47 +345,55 @@ export default function ResultsGrid({
             {view.map(({ cells, orig }, r) => {
               const isSelected = selectedRow === orig;
               const isLinked = highlightIndex === orig;
+              const rowBg = isSelected
+                ? "bg-primary/15"
+                : isLinked
+                  ? "bg-score/15"
+                  : "";
               return (
                 <tr
                   key={orig}
                   data-row={r}
                   onMouseEnter={() => onRowHover?.(orig)}
-                  className={cn(
-                    "border-t border-border/60 transition-colors",
-                    isSelected && "bg-primary/15",
-                    isLinked && !isSelected && "bg-score/15",
-                    !isSelected && !isLinked && "hover:bg-muted/60"
-                  )}
+                  className={cn("transition-colors", rowBg, !rowBg && "hover:bg-muted/60")}
                 >
                   <td
                     className={cn(
-                      "sticky left-0 z-10 w-10 whitespace-nowrap px-2 py-1 text-right text-muted-foreground",
-                      isSelected
-                        ? "bg-primary/15"
-                        : isLinked
-                          ? "bg-score/15"
-                          : "bg-card"
+                      "sticky left-0 z-10 w-10 border-b border-border/40 px-2 text-right font-mono text-muted-foreground",
+                      pad,
+                      isSelected ? "bg-primary/15" : isLinked ? "bg-score/15" : "bg-card"
                     )}
                   >
                     {orig + 1}
                   </td>
-                  {colOrder.map((ci, c) => (
-                    <td
-                      key={ci}
-                      data-cell={`${r}-${c}`}
-                      tabIndex={focus.r === r && focus.c === c ? 0 : -1}
-                      onKeyDown={(e) => onCellKeyDown(e, r, c)}
-                      onFocus={() => setFocus({ r, c })}
-                      onClick={() => selectRow(isSelected ? null : r)}
-                      title={cells[ci] ?? ""}
-                      className={cn(
-                        "max-w-64 truncate whitespace-nowrap px-3 py-1 outline-none",
-                        "focus:ring-1 focus:ring-inset focus:ring-primary"
-                      )}
-                    >
-                      {cells[ci] === null ? "∅" : cells[ci]}
-                    </td>
-                  ))}
+                  {colOrder.map((ci, c) => {
+                    const raw = cells[ci];
+                    const numeric = domains[ci] !== null;
+                    const tint = heat ? cellTint(raw, domains[ci]) : undefined;
+                    return (
+                      <td
+                        key={ci}
+                        data-cell={`${r}-${c}`}
+                        tabIndex={focus.r === r && focus.c === c ? 0 : -1}
+                        onKeyDown={(e) => onCellKeyDown(e, r, c)}
+                        onFocus={() => setFocus({ r, c })}
+                        onClick={() => selectRow(isSelected ? null : r)}
+                        title={raw ?? ""}
+                        style={tint && !rowBg ? { backgroundColor: tint } : undefined}
+                        className={cn(
+                          "max-w-64 truncate whitespace-nowrap border-b border-border/40 px-3 outline-none",
+                          pad,
+                          numeric
+                            ? "font-display text-right text-[13px] tabular-nums"
+                            : "font-mono",
+                          sort?.col === ci && !tint && !rowBg && "bg-muted/40",
+                          "focus:ring-1 focus:ring-inset focus:ring-primary"
+                        )}
+                      >
+                        {raw === null ? "∅" : raw}
+                      </td>
+                    );
+                  })}
                 </tr>
               );
             })}
@@ -364,6 +404,38 @@ export default function ResultsGrid({
             no rows match the column filters
           </p>
         ) : null}
+      </div>
+
+      {/* Status bar — the hotkeys are only real if they're discoverable. */}
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-b-lg border border-t-0 border-border/60 bg-muted/40 px-3 py-1.5 font-mono text-[10px] uppercase tracking-wide text-muted-foreground">
+        <span className="inline-flex items-center gap-1.5 text-foreground">
+          <span className="size-1.5 animate-pulse rounded-full bg-status-success" />
+          {view.length.toLocaleString("en-US")}
+          {view.length !== rows.length ? ` / ${rows.length.toLocaleString("en-US")}` : ""} rows
+        </span>
+        <span className="hidden sm:inline">↑↓←→ move</span>
+        <span className="hidden sm:inline">
+          <kbd className="text-foreground">f</kbd> filter
+        </span>
+        <span className="hidden sm:inline">
+          <kbd className="text-foreground">s</kbd> sort
+        </span>
+        <span className="hidden md:inline">
+          <kbd className="text-foreground">a</kbd>/<kbd className="text-foreground">d</kbd> scroll
+        </span>
+        <span className="hidden md:inline">
+          <kbd className="text-foreground">w</kbd>/<kbd className="text-foreground">e</kbd> density
+        </span>
+        <button
+          onClick={() => setHeat((v) => !v)}
+          className={cn(
+            "ml-auto inline-flex items-center gap-1 uppercase hover:text-foreground",
+            heat && "text-primary"
+          )}
+          title="Shade numeric cells by distance from the column baseline (h)"
+        >
+          <Flame className="size-3" /> heat <kbd>h</kbd>
+        </button>
       </div>
     </div>
   );

--- a/frontend/lib/platform/scales.ts
+++ b/frontend/lib/platform/scales.ts
@@ -1,0 +1,152 @@
+/**
+ * Value→color encoding for the platform's dense data surfaces.
+ *
+ * Two rules, both borrowed from the sites this platform is chasing:
+ *
+ * 1. **Color the delta, not the value.** A raw rate shaded min→max says only
+ *    "big number". Shading a value's distance from a baseline — zero for signed
+ *    metrics like EPA, the column median otherwise — says "unusual", which is
+ *    what a scanner is actually looking for.
+ * 2. **Quantize.** Six buckets at fixed cut points read as categories at a
+ *    glance; a continuous ramp reads as mush. (buckets.peterbeshai.com uses
+ *    ±3%/±9% thresholds on FG% vs league average; same principle, generalized.)
+ *
+ * Every stop is a `color-mix()` against the THEME TOKENS rather than baked hex,
+ * so a shaded cell re-derives itself in light and dark mode and no new colors
+ * enter the palette (DESIGN.md: extend the token table first). Scoreboard amber
+ * stays reserved for its accent slots — encoding uses SDV blue for above-
+ * baseline and destructive red for below, the most colorblind-tolerable
+ * diverging pair already in the tokens.
+ */
+
+/** Percentile fields arrive as 0–1 from some producers and 0–100 from others. */
+export function asPercentile(p: number | null): number | null {
+  if (p == null || Number.isNaN(p)) return null;
+  return Math.round(p > 1 ? p : p * 100);
+}
+
+/** Tint strength per bucket. Capped where cell text starts losing contrast. */
+const BUCKET_TINT = [0, 7, 14, 24] as const;
+
+/** |z|-style cut points in units of "share of the half-domain". */
+const CUTS = [0.12, 0.38, 0.7] as const;
+
+export type Domain = {
+  min: number;
+  max: number;
+  /** The value that reads as "normal" — 0 for signed metrics, else the median. */
+  base: number;
+  /** True when the column straddles zero (EPA-like) rather than being a rate. */
+  signed: boolean;
+  /** +1 when higher is better, −1 when lower is better (see `polarity`). */
+  polarity: 1 | -1;
+};
+
+/**
+ * Which direction is "good" for a column.
+ *
+ * Readers decode color as good-vs-bad, not as positive-vs-negative, so a scale
+ * keyed on sign lies about every metric where lower is better: a defense
+ * allowing −0.37 EPA/play is elite and must not read as the reddest cell in the
+ * table. Names are matched against the vocabulary the warehouse actually uses.
+ */
+const LOWER_IS_BETTER =
+  /(^|_)(def|defensive|allowed|against|opp|opponent)(_|$)|(^|_)(turnovers?|tov|interceptions?|ints?|fumbles?|sacks_allowed|penalt(y|ies)|losses|errors?|era|whip|rank)(_|$)/i;
+
+/** Metrics whose name contains a "good" noun that would otherwise match above. */
+const OVERRIDE_HIGHER_IS_BETTER = /(^|_)(havoc|takeaways?|forced|def_epa_added|stops)(_|$)/i;
+
+export function polarity(name?: string): 1 | -1 {
+  if (!name) return 1;
+  if (OVERRIDE_HIGHER_IS_BETTER.test(name)) return 1;
+  return LOWER_IS_BETTER.test(name) ? -1 : 1;
+}
+
+/**
+ * Bucketed diverging tint around `base`. Returns undefined inside the dead zone
+ * so a table of unremarkable values stays clean rather than uniformly washed.
+ */
+export function tintFor(value: number, domain: Domain): string | undefined {
+  const span = Math.max(Math.abs(domain.max - domain.base), Math.abs(domain.base - domain.min));
+  if (!span) return undefined;
+  // Polarity flips the hue, never the magnitude: an elite defensive number
+  // stays as far from the baseline as it was, it just reads as good.
+  const t = ((value - domain.base) / span) * domain.polarity; // −1 … +1
+  const mag = Math.min(1, Math.abs(t));
+  let bucket = 0;
+  for (let i = 0; i < CUTS.length; i++) if (mag > CUTS[i]) bucket = i + 1;
+  const strength = BUCKET_TINT[bucket];
+  if (!strength) return undefined;
+  const token = t > 0 ? "var(--color-primary)" : "var(--color-destructive)";
+  return `color-mix(in oklab, ${token} ${strength}%, transparent)`;
+}
+
+/** Text emphasis for an elite percentile — databallr's gold sub-value idea,
+ *  re-pointed at the scoreboard token so it stays on-palette. */
+export function percentileClass(pct: number | null): string {
+  const p = asPercentile(pct);
+  if (p == null) return "text-muted-foreground";
+  if (p >= 90) return "text-score-ink dark:text-score font-semibold";
+  if (p >= 75) return "text-foreground";
+  return "text-muted-foreground";
+}
+
+/**
+ * Derive a column's encoding domain from its visible values. Returns null for
+ * non-numeric columns, constant columns, and identifier-ish columns (ids, years,
+ * counts of one) where shading would be noise rather than signal.
+ */
+export function columnDomain(values: (string | null)[], name?: string): Domain | null {
+  if (name && /(^|_)(id|ids|season|year|week|game_id|play_id)$/i.test(name)) return null;
+  const nums: number[] = [];
+  for (const v of values) {
+    if (v == null || v === "") continue;
+    const n = Number(v);
+    if (Number.isNaN(n)) return null; // any non-numeric ⇒ not an encodable column
+    nums.push(n);
+  }
+  if (nums.length < 4) return null;
+  const min = Math.min(...nums);
+  const max = Math.max(...nums);
+  if (min === max) return null;
+  const sorted = [...nums].sort((a, b) => a - b);
+  const mid = sorted.length % 2
+    ? sorted[(sorted.length - 1) / 2]
+    : (sorted[sorted.length / 2 - 1] + sorted[sorted.length / 2]) / 2;
+  const signed = min < 0 && max > 0;
+  return { min, max, base: signed ? 0 : mid, signed, polarity: polarity(name) };
+}
+
+/** The tint for one cell given its column domain; undefined = leave it clean. */
+export function cellTint(value: string | null, domain: Domain | null): string | undefined {
+  if (!domain || value == null || value === "") return undefined;
+  const n = Number(value);
+  if (Number.isNaN(n)) return undefined;
+  return tintFor(n, domain);
+}
+
+/** 1-2-5 "nice" tick generator — d3-array's algorithm without the dependency. */
+export function niceTicks(min: number, max: number, count = 5): number[] {
+  if (!Number.isFinite(min) || !Number.isFinite(max) || min === max) return [min];
+  const raw = (max - min) / count;
+  const mag = 10 ** Math.floor(Math.log10(raw));
+  const norm = raw / mag;
+  const step = (norm >= 7.5 ? 10 : norm >= 3 ? 5 : norm >= 1.5 ? 2 : 1) * mag;
+  const out: number[] = [];
+  for (let t = Math.ceil(min / step) * step; t <= max + step * 1e-9; t += step) {
+    out.push(Number(t.toFixed(10)));
+  }
+  return out;
+}
+
+/** Sign-aware delta formatting: `+0.42` / `−0.13`, with a direction glyph. */
+export function formatDelta(value: number, digits = 2): { text: string; glyph: string; tone: string } {
+  const glyph = value > 0 ? "▲" : value < 0 ? "▼" : "–";
+  const tone =
+    value > 0
+      ? "text-status-success-ink dark:text-status-success"
+      : value < 0
+        ? "text-status-failed-ink dark:text-status-failed"
+        : "text-muted-foreground";
+  return { text: `${value > 0 ? "+" : ""}${value.toFixed(digits)}`, glyph, tone };
+}


### PR DESCRIPTION
Ports interaction + encoding ideas from the dashboards studied in `sdv-next-clone` (databallr, buckets, blazingthenets, shotline) onto the platform grid — using SDV tokens and type, not their palettes.

### Encoding — `lib/platform/scales.ts` (new)
- **Color the delta, not the value.** Baseline is `0` for signed metrics (EPA straddles zero), the **column median** otherwise. A raw min→max ramp only says "big number"; distance-from-baseline says "unusual".
- **Quantized** into 4 buckets at fixed cut points — categories read at a glance, continuous ramps read as mush.
- **Polarity.** Readers decode color as good-vs-bad, not positive-vs-negative. Columns where lower is better (`def_*`, `allowed`, `opp_*`, turnovers, ranks, ERA…) invert the hue. Without it, a defense allowing `-0.37` EPA/play — the best in the table — renders as the **reddest cell on the page**. Caught by screenshotting, not by types.
- Stops are `color-mix()` against the **theme tokens**, so shading re-derives in light/dark and no new colors enter the palette; scoreboard amber stays reserved for its accent slots.
- Identifier columns (`id`/`season`/`year`/`week`) excluded. Also ships `niceTicks` (1-2-5 ticks, no d3 dep) and `formatDelta`.

### Grid
- Numeric cells in the **condensed display face** + `tabular-nums` — density from typography, which is how the reference tables fit many columns.
- **Sticky status bar** with live row count + hotkey legend.
- **Real key handlers**: `a`/`d` scroll by viewport, `w`/`e` density, `h` heat, plus existing arrows/`f`/`s`. (The reference implementation advertised hotkeys in a panel but bound no listeners.)
- Sorted-column tint; `border-separate`/`border-spacing-0` so cell borders survive under the sticky header.

`tsc` + `eslint` + `next build` green.

## Summary by Sourcery

Introduce value-encoded heatmap-style formatting and richer keyboard ergonomics to the platform results grid.

New Features:
- Add column-based numeric encoding domains and cell tinting to render the grid as a bucketed diverging heatmap.
- Display numeric cells in a condensed, tabular-figure display face with adjustable row density.
- Add keyboard and UI controls for horizontal viewport scrolling, density changes, and toggling heat encoding, with a sticky status bar legend.

Enhancements:
- Refine grid keyboard handling for Home/End behavior and case-insensitive hotkeys, and clarify row selection semantics.
- Visually distinguish sorted columns and linked rows while preserving cell borders under sticky headers via layout tweaks.
- Extract reusable scaling utilities for numeric domains, percentiles, ticks, deltas, and polarity handling into a shared platform scales module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added numeric heatmap shading to help compare values at a glance.
  * Added row-density controls and horizontal scrolling for easier data exploration.
  * Added status information showing row counts and available grid controls.
  * Added keyboard shortcuts for horizontal navigation, heatmap toggling, and density changes.
  * Added clearer active-filter visibility and improved sorting, selection, and link highlighting.
  * Added baseline-relative color indicators, percentile styling, readable numeric tick marks, and signed change formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->