### PR TITLE
fix(wp): explain a missing win-probability column instead of leaking a binder error

### DIFF
--- a/frontend/app/(platform)/platform/wp/WpClient.tsx
+++ b/frontend/app/(platform)/platform/wp/WpClient.tsx
@@ -214,6 +214,23 @@ export default function WpClient() {
     try {
       const c = sport.cols;
       const src = `read_parquet('${proxyUrl(sport, asset)}')`;
+      // Preflight the schema. Release columns drift — the mbb/wbb pbp releases
+      // dropped their win-probability enrichment entirely — and without this
+      // the user just gets a raw DuckDB binder error. Checking first turns that
+      // into an explanation, and self-heals the moment the column returns.
+      const described = await runQuery(`DESCRIBE SELECT * FROM ${src}`, 2000);
+      const nameIdx0 = described.columns.indexOf("column_name");
+      const have = new Set(described.rows.map((r) => r[nameIdx0] ?? ""));
+      const required = [c.gameId, c.order, c.wp, c.period, c.text, c.homeName, c.awayName];
+      const missing = required.filter((col) => !have.has(col));
+      if (missing.length) {
+        setError(
+          `${sport.label} ${asset.replace(sport.assetPrefix, "").replace(".parquet", "")}: the ` +
+            `${sport.tag} release is missing ${missing.map((m) => `\`${m}\``).join(", ")}. ` +
+            `Win probability isn't published for this sport right now — try CFB or NFL.`
+        );
+        return;
+      }
       const weekSel = c.week ? `any_value(${q(c.week)})` : "NULL";
       const res = await runQuery(
         `SELECT CAST(${q(c.gameId)} AS VARCHAR) AS id, any_value(${q(c.homeName)}) AS home, any_value(${q(c.awayName)}) AS away, ${weekSel} AS week FROM ${src} GROUP BY 1 ORDER BY week NULLS LAST, home`,


### PR DESCRIPTION
The `mbb`/`wbb` pbp releases **no longer carry the win-probability enrichment** that `content/wp.ts` documents — `home_win_prob` is absent from every season 2022–2026, and there are no probability columns at all. Selecting an MBB season ran a `SELECT` against a nonexistent column and surfaced a raw DuckDB binder error.

Now the loader preflights the schema with `DESCRIBE` and reports which columns are missing, from which release tag, pointing at the sports that do work. Checking at runtime rather than hardcoding "mbb is broken" means the page **self-heals** the moment the producer restores the column.

**CFB was verified healthy** — every mapped column present 2022–2025, and `play_by_play_2025.parquet` reads 165,850 rows with zero nulls in `home_wp_before`. Its errors coincide with the producers republishing the entire `espn_cfb_pbp` release today (assets re-uploaded 12:47–13:35Z); GitHub release-asset replacement is not atomic, so fetches during that window 404 or return partial content.

Upstream regression tracked separately.

## Summary by Sourcery

Bug Fixes:
- Prevent platform win-probability view from crashing on sports whose play-by-play releases no longer include the expected win-probability columns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for required game data fields before loading results.
  * Displays a sport- and season-specific error when required data is unavailable.
  * Prevents incomplete or invalid game data from being loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->