### PR TITLE
feat(platform): admin dashboard, telemetry beacon, API docs link

### DIFF
--- a/frontend/app/(platform)/platform/admin/AdminOverviewClient.tsx
+++ b/frontend/app/(platform)/platform/admin/AdminOverviewClient.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import useSWR from "swr";
+import { Sparkline } from "@components/platform/widgets";
+
+const fetcher = (u: string) =>
+  fetch(u).then((r) => {
+    if (!r.ok) throw new Error(String(r.status));
+    return r.json();
+  });
+
+/** Shared fetch hook for every /platform/admin page — server-proxied,
+ *  admin-gated `/api/platform/admin/{name}` endpoints, refreshed every 30s. */
+export function useAdmin<T>(name: string, params = "") {
+  return useSWR<T>(`/api/platform/admin/${name}${params}`, fetcher, {
+    refreshInterval: 30_000,
+  });
+}
+
+type Summary = {
+  requests: { bucket: string; n: number; errors: number }[];
+  top_endpoints: { route_pattern: string; n: number }[];
+  latency: { route_pattern: string; p50: number; p95: number; p99: number }[];
+  active_keys: number;
+};
+
+function Stat({
+  label,
+  value,
+  extra,
+}: {
+  label: string;
+  value: string;
+  extra?: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <p className="font-inter text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-1 font-display text-2xl font-bold tracking-tight">{value}</p>
+      {extra ? <div className="mt-2">{extra}</div> : null}
+    </div>
+  );
+}
+
+function TopEndpoints({ rows }: { rows: Summary["top_endpoints"] }) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <h3 className="mb-2 font-barlow text-lg font-semibold">Top endpoints</h3>
+      <div className="overflow-x-auto rounded-lg border border-border">
+        <table className="w-full text-left font-inter text-sm">
+          <thead className="bg-muted text-xs uppercase text-muted-foreground">
+            <tr>
+              <th className="px-4 py-2">Route</th>
+              <th className="px-4 py-2">Requests</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.route_pattern} className="border-t border-border">
+                <td className="px-4 py-2 font-mono text-xs">{r.route_pattern}</td>
+                <td className="px-4 py-2">{r.n.toLocaleString()}</td>
+              </tr>
+            ))}
+            {rows.length === 0 ? (
+              <tr>
+                <td className="px-4 py-2 text-muted-foreground" colSpan={2}>
+                  No data.
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function LatencyTable({ rows }: { rows: Summary["latency"] }) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <h3 className="mb-2 font-barlow text-lg font-semibold">Latency by route</h3>
+      <div className="overflow-x-auto rounded-lg border border-border">
+        <table className="w-full text-left font-inter text-sm">
+          <thead className="bg-muted text-xs uppercase text-muted-foreground">
+            <tr>
+              <th className="px-4 py-2">Route</th>
+              <th className="px-4 py-2">p50</th>
+              <th className="px-4 py-2">p95</th>
+              <th className="px-4 py-2">p99</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.route_pattern} className="border-t border-border">
+                <td className="px-4 py-2 font-mono text-xs">{r.route_pattern}</td>
+                <td className="px-4 py-2">{Math.round(r.p50)} ms</td>
+                <td className="px-4 py-2">{Math.round(r.p95)} ms</td>
+                <td className="px-4 py-2">{Math.round(r.p99)} ms</td>
+              </tr>
+            ))}
+            {rows.length === 0 ? (
+              <tr>
+                <td className="px-4 py-2 text-muted-foreground" colSpan={4}>
+                  No data.
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default function AdminOverviewClient() {
+  const { data, error } = useAdmin<Summary>("summary", "?hours=24");
+  if (error)
+    return (
+      <p className="text-sm text-muted-foreground">
+        Couldn&apos;t load summary — is the admin key configured?
+      </p>
+    );
+  if (!data) return <p className="text-sm text-muted-foreground">Loading…</p>;
+  const reqSeries = data.requests.map((b) => b.n);
+  const errTotal = data.requests.reduce((s, b) => s + b.errors, 0);
+  const reqTotal = data.requests.reduce((s, b) => s + b.n, 0);
+  return (
+    <div className="space-y-6">
+      <div className="mb-2 flex items-center justify-between gap-4">
+        <h1 className="font-display text-2xl font-bold tracking-tight">Admin</h1>
+      </div>
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        <Stat
+          label="Requests (24h)"
+          value={reqTotal.toLocaleString()}
+          extra={<Sparkline values={reqSeries} />}
+        />
+        <Stat
+          label="Error rate"
+          value={reqTotal ? `${((100 * errTotal) / reqTotal).toFixed(2)}%` : "–"}
+        />
+        <Stat label="Active keys" value={String(data.active_keys)} />
+        <Stat
+          label="Slowest p99"
+          value={data.latency[0] ? `${Math.round(data.latency[0].p99)} ms` : "–"}
+        />
+      </div>
+      <TopEndpoints rows={data.top_endpoints} />
+      <LatencyTable rows={data.latency} />
+    </div>
+  );
+}

--- a/frontend/app/(platform)/platform/admin/AdminTabs.tsx
+++ b/frontend/app/(platform)/platform/admin/AdminTabs.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@lib/utils";
+
+const TABS = [
+  { href: "/platform/admin", label: "Overview" },
+  { href: "/platform/admin/traffic", label: "Traffic" },
+  { href: "/platform/admin/keys", label: "Keys" },
+  { href: "/platform/admin/errors", label: "Errors" },
+  { href: "/platform/admin/site", label: "Site" },
+];
+
+export default function AdminTabs() {
+  const pathname = usePathname() ?? "/platform/admin";
+  return (
+    <div className="mb-4 flex flex-wrap gap-2">
+      {TABS.map((t) => {
+        const active = t.href === "/platform/admin" ? pathname === t.href : pathname.startsWith(t.href);
+        return (
+          <Link
+            key={t.href}
+            href={t.href}
+            className={cn(
+              "rounded-full px-3 py-1 font-inter text-sm font-medium transition-colors",
+              active ? "bg-primary text-primary-foreground" : "bg-primary/10 text-primary hover:bg-primary/20"
+            )}
+          >
+            {t.label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/app/(platform)/platform/admin/errors/ErrorsClient.tsx
+++ b/frontend/app/(platform)/platform/admin/errors/ErrorsClient.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState } from "react";
+import { timeAgo } from "@components/platform/widgets";
+import { useAdmin } from "../AdminOverviewClient";
+
+type ErrorRow = {
+  message: string;
+  service: string;
+  n: number;
+  last_ts: string | null;
+  sample_stack: string | null;
+};
+
+export default function ErrorsClient() {
+  const { data, error } = useAdmin<{ rows: ErrorRow[] }>("errors");
+  const rows = data?.rows ?? [];
+  const [expanded, setExpanded] = useState<number | null>(null);
+
+  return (
+    <div className="space-y-4">
+      <div className="mb-2 flex items-center justify-between gap-4">
+        <h1 className="font-display text-2xl font-bold tracking-tight">Errors</h1>
+      </div>
+      {error ? (
+        <p className="text-sm text-muted-foreground">Couldn&apos;t load errors.</p>
+      ) : !data ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : rows.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No errors recorded.</p>
+      ) : (
+        <ul className="space-y-2">
+          {rows.map((r, i) => (
+            <li key={`${r.service}-${r.message}-${i}`} className="rounded-lg border border-border bg-card p-4">
+              <button
+                type="button"
+                onClick={() => setExpanded(expanded === i ? null : i)}
+                className="flex w-full flex-wrap items-center justify-between gap-2 text-left"
+              >
+                <span className="min-w-0 flex-1">
+                  <span className="font-mono text-xs text-muted-foreground">{r.service}</span>
+                  <p className="truncate font-inter text-sm font-medium">{r.message}</p>
+                </span>
+                <span className="inline-block rounded-full bg-status-failed/15 px-2 py-0.5 font-mono text-xs font-semibold text-status-failed-ink dark:text-status-failed">
+                  {r.n.toLocaleString()}
+                </span>
+                <span className="font-inter text-xs text-muted-foreground">
+                  {timeAgo(r.last_ts)}
+                </span>
+              </button>
+              {expanded === i && r.sample_stack ? (
+                <pre className="mt-3 overflow-x-auto text-xs">{r.sample_stack}</pre>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/(platform)/platform/admin/errors/page.tsx
+++ b/frontend/app/(platform)/platform/admin/errors/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next";
+import ErrorsClient from "./ErrorsClient";
+
+export const metadata: Metadata = { title: "Errors" };
+
+export default function PlatformAdminErrorsPage() {
+  return <ErrorsClient />;
+}

--- a/frontend/app/(platform)/platform/admin/keys/KeysClient.tsx
+++ b/frontend/app/(platform)/platform/admin/keys/KeysClient.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { timeAgo } from "@components/platform/widgets";
+import { useAdmin } from "../AdminOverviewClient";
+
+type KeyRow = {
+  key_id: string;
+  requests: number;
+  rows_served: number;
+  top_tables: { table_name: string; n: number }[];
+  last_seen: string | null;
+};
+
+export default function KeysClient() {
+  const { data, error } = useAdmin<{ rows: KeyRow[] }>("keys");
+  const rows = data?.rows ?? [];
+
+  return (
+    <div className="space-y-4">
+      <div className="mb-2 flex items-center justify-between gap-4">
+        <h1 className="font-display text-2xl font-bold tracking-tight">Keys</h1>
+      </div>
+      {error ? (
+        <p className="text-sm text-muted-foreground">Couldn&apos;t load keys.</p>
+      ) : !data ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-border">
+          <table className="w-full text-left font-inter text-sm">
+            <thead className="bg-muted text-xs uppercase text-muted-foreground">
+              <tr>
+                <th className="px-4 py-2">Key</th>
+                <th className="px-4 py-2">Requests</th>
+                <th className="px-4 py-2">Rows served</th>
+                <th className="px-4 py-2">Top tables</th>
+                <th className="px-4 py-2">Last seen</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.key_id} className="border-t border-border">
+                  <td className="px-4 py-2 font-mono text-xs">{r.key_id}</td>
+                  <td className="px-4 py-2">{r.requests.toLocaleString()}</td>
+                  <td className="px-4 py-2">{r.rows_served.toLocaleString()}</td>
+                  <td className="px-4 py-2 text-muted-foreground">
+                    {r.top_tables.map((t) => t.table_name).join(", ") || "–"}
+                  </td>
+                  <td className="px-4 py-2 text-muted-foreground">{timeAgo(r.last_seen)}</td>
+                </tr>
+              ))}
+              {rows.length === 0 ? (
+                <tr>
+                  <td className="px-4 py-2 text-muted-foreground" colSpan={5}>
+                    No active keys.
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/(platform)/platform/admin/keys/page.tsx
+++ b/frontend/app/(platform)/platform/admin/keys/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next";
+import KeysClient from "./KeysClient";
+
+export const metadata: Metadata = { title: "Keys" };
+
+export default function PlatformAdminKeysPage() {
+  return <KeysClient />;
+}

--- a/frontend/app/(platform)/platform/admin/layout.tsx
+++ b/frontend/app/(platform)/platform/admin/layout.tsx
@@ -1,0 +1,25 @@
+import { auth } from "@lib/auth";
+import AdminTabs from "./AdminTabs";
+
+export const metadata = { title: "Admin" };
+export const dynamic = "force-dynamic";
+
+export default async function AdminLayout({ children }: { children: React.ReactNode }) {
+  const session = await auth();
+  if (session?.role !== "admin") {
+    return (
+      <div className="mx-auto mt-16 max-w-md rounded-lg border border-border bg-card p-6 text-center">
+        <p className="font-display text-sm font-bold uppercase tracking-wide">Admins only</p>
+        <p className="mt-2 text-sm text-muted-foreground">
+          This area needs the org admin role.
+        </p>
+      </div>
+    );
+  }
+  return (
+    <>
+      <AdminTabs />
+      {children}
+    </>
+  );
+}

--- a/frontend/app/(platform)/platform/admin/page.tsx
+++ b/frontend/app/(platform)/platform/admin/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next";
+import AdminOverviewClient from "./AdminOverviewClient";
+
+export const metadata: Metadata = { title: "Admin" };
+
+export default function PlatformAdminPage() {
+  return <AdminOverviewClient />;
+}

--- a/frontend/app/(platform)/platform/admin/site/SiteClient.tsx
+++ b/frontend/app/(platform)/platform/admin/site/SiteClient.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useAdmin } from "../AdminOverviewClient";
+
+type Site = {
+  pageviews: { path: string; n: number; uniques: number }[];
+  referrers: { referrer: string; n: number }[];
+  vitals: { name: string; p75: number }[];
+  actions: { name: string; n: number }[];
+};
+
+function formatVital(name: string, p75: number): string {
+  return name.toUpperCase() === "CLS" ? p75.toFixed(3) : `${Math.round(p75)} ms`;
+}
+
+export default function SiteClient() {
+  const { data, error } = useAdmin<Site>("site");
+
+  return (
+    <div className="space-y-6">
+      <div className="mb-2 flex items-center justify-between gap-4">
+        <h1 className="font-display text-2xl font-bold tracking-tight">Site</h1>
+      </div>
+      {error ? (
+        <p className="text-sm text-muted-foreground">Couldn&apos;t load site stats.</p>
+      ) : !data ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : (
+        <>
+          <div className="rounded-lg border border-border bg-card p-4">
+            <h3 className="mb-2 font-barlow text-lg font-semibold">Web vitals</h3>
+            <div className="flex flex-wrap gap-6">
+              {data.vitals.map((v) => (
+                <div key={v.name}>
+                  <p className="font-inter text-xs uppercase tracking-wide text-muted-foreground">
+                    {v.name}
+                  </p>
+                  <p className="font-display text-lg font-bold">{formatVital(v.name, v.p75)}</p>
+                </div>
+              ))}
+              {data.vitals.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No vitals recorded.</p>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <div className="rounded-lg border border-border bg-card p-4">
+              <h3 className="mb-2 font-barlow text-lg font-semibold">Pageviews</h3>
+              <div className="overflow-x-auto rounded-lg border border-border">
+                <table className="w-full text-left font-inter text-sm">
+                  <thead className="bg-muted text-xs uppercase text-muted-foreground">
+                    <tr>
+                      <th className="px-4 py-2">Path</th>
+                      <th className="px-4 py-2">Views</th>
+                      <th className="px-4 py-2">Uniques</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.pageviews.map((p) => (
+                      <tr key={p.path} className="border-t border-border">
+                        <td className="px-4 py-2 font-mono text-xs">{p.path}</td>
+                        <td className="px-4 py-2">{p.n.toLocaleString()}</td>
+                        <td className="px-4 py-2">{p.uniques.toLocaleString()}</td>
+                      </tr>
+                    ))}
+                    {data.pageviews.length === 0 ? (
+                      <tr>
+                        <td className="px-4 py-2 text-muted-foreground" colSpan={3}>
+                          No pageviews.
+                        </td>
+                      </tr>
+                    ) : null}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            <div className="rounded-lg border border-border bg-card p-4">
+              <h3 className="mb-2 font-barlow text-lg font-semibold">API Referrers</h3>
+              <p className="mb-2 font-inter text-xs text-muted-foreground">
+                Sourced from API request referrers, not client pageview referrers.
+              </p>
+              <div className="overflow-x-auto rounded-lg border border-border">
+                <table className="w-full text-left font-inter text-sm">
+                  <thead className="bg-muted text-xs uppercase text-muted-foreground">
+                    <tr>
+                      <th className="px-4 py-2">Referrer</th>
+                      <th className="px-4 py-2">Requests</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.referrers.map((r) => (
+                      <tr key={r.referrer} className="border-t border-border">
+                        <td className="px-4 py-2 font-mono text-xs">{r.referrer || "–"}</td>
+                        <td className="px-4 py-2">{r.n.toLocaleString()}</td>
+                      </tr>
+                    ))}
+                    {data.referrers.length === 0 ? (
+                      <tr>
+                        <td className="px-4 py-2 text-muted-foreground" colSpan={2}>
+                          No referrers.
+                        </td>
+                      </tr>
+                    ) : null}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-border bg-card p-4">
+            <h3 className="mb-2 font-barlow text-lg font-semibold">Actions</h3>
+            <div className="overflow-x-auto rounded-lg border border-border">
+              <table className="w-full text-left font-inter text-sm">
+                <thead className="bg-muted text-xs uppercase text-muted-foreground">
+                  <tr>
+                    <th className="px-4 py-2">Action</th>
+                    <th className="px-4 py-2">Count</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.actions.map((a) => (
+                    <tr key={a.name} className="border-t border-border">
+                      <td className="px-4 py-2 font-mono text-xs">{a.name}</td>
+                      <td className="px-4 py-2">{a.n.toLocaleString()}</td>
+                    </tr>
+                  ))}
+                  {data.actions.length === 0 ? (
+                    <tr>
+                      <td className="px-4 py-2 text-muted-foreground" colSpan={2}>
+                        No actions.
+                      </td>
+                    </tr>
+                  ) : null}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/(platform)/platform/admin/site/page.tsx
+++ b/frontend/app/(platform)/platform/admin/site/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next";
+import SiteClient from "./SiteClient";
+
+export const metadata: Metadata = { title: "Site" };
+
+export default function PlatformAdminSitePage() {
+  return <SiteClient />;
+}

--- a/frontend/app/(platform)/platform/admin/traffic/TrafficClient.tsx
+++ b/frontend/app/(platform)/platform/admin/traffic/TrafficClient.tsx
@@ -7,6 +7,8 @@ import {
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@lib/utils";
 import { useAdmin } from "../AdminOverviewClient";
 
 type RequestRow = {
@@ -52,11 +54,36 @@ function HttpStatusBadge({ status }: { status: number | null | undefined }) {
   );
 }
 
+/** Stable per-row identity for expansion state — an array index would track
+ *  "row 3" across a 30s SWR refresh even after the underlying rows reorder,
+ *  silently expanding the wrong request. */
+function rowKey(r: RequestRow): string {
+  return `${r.ts}|${r.key_id ?? ""}|${r.path}`;
+}
+
+type TableMeta = { expandedKey: string | null; toggle: (key: string) => void };
+
 const columnHelper = createColumnHelper<RequestRow>();
 const columns = [
   columnHelper.accessor("ts", {
     header: "Time",
-    cell: (c) => <span className="font-mono text-xs">{c.getValue()}</span>,
+    cell: (c) => {
+      const meta = c.table.options.meta as TableMeta;
+      const key = rowKey(c.row.original);
+      const isExpanded = meta.expandedKey === key;
+      return (
+        <button
+          type="button"
+          onClick={() => meta.toggle(key)}
+          aria-expanded={isExpanded}
+          aria-label={isExpanded ? "Collapse request details" : "Expand request details"}
+          className="flex items-center gap-1.5 font-mono text-xs hover:text-primary"
+        >
+          <ChevronRight className={cn("size-3 shrink-0 transition-transform", isExpanded && "rotate-90")} />
+          {c.getValue()}
+        </button>
+      );
+    },
   }),
   columnHelper.accessor("method", { header: "Method" }),
   columnHelper.accessor("path", {
@@ -81,7 +108,7 @@ export default function TrafficClient() {
   const [keyId, setKeyId] = useState("");
   const [pathPrefix, setPathPrefix] = useState("");
   const [service, setService] = useState("");
-  const [expanded, setExpanded] = useState<number | null>(null);
+  const [expandedKey, setExpandedKey] = useState<string | null>(null);
 
   const qs = useMemo(() => {
     const p = new URLSearchParams({ hours, limit: "200" });
@@ -99,6 +126,10 @@ export default function TrafficClient() {
     data: rows,
     columns,
     getCoreRowModel: getCoreRowModel(),
+    meta: {
+      expandedKey,
+      toggle: (key: string) => setExpandedKey((cur) => (cur === key ? null : key)),
+    } satisfies TableMeta,
   });
 
   return (
@@ -170,29 +201,29 @@ export default function TrafficClient() {
               ))}
             </thead>
             <tbody>
-              {table.getRowModel().rows.map((row, i) => (
-                <Fragment key={row.id}>
-                  <tr
-                    onClick={() => setExpanded(expanded === i ? null : i)}
-                    className="cursor-pointer border-t border-border hover:bg-secondary/50"
-                  >
-                    {row.getVisibleCells().map((cell) => (
-                      <td key={cell.id} className="px-4 py-2">
-                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                      </td>
-                    ))}
-                  </tr>
-                  {expanded === i ? (
-                    <tr className="border-t border-border bg-secondary/30">
-                      <td colSpan={columns.length} className="px-4 py-2">
-                        <pre className="overflow-x-auto text-xs">
-                          {JSON.stringify(row.original, null, 2)}
-                        </pre>
-                      </td>
+              {table.getRowModel().rows.map((row) => {
+                const isExpanded = expandedKey === rowKey(row.original);
+                return (
+                  <Fragment key={row.id}>
+                    <tr className="border-t border-border hover:bg-secondary/50">
+                      {row.getVisibleCells().map((cell) => (
+                        <td key={cell.id} className="px-4 py-2">
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </td>
+                      ))}
                     </tr>
-                  ) : null}
-                </Fragment>
-              ))}
+                    {isExpanded ? (
+                      <tr className="border-t border-border bg-secondary/30">
+                        <td colSpan={columns.length} className="px-4 py-2">
+                          <pre className="overflow-x-auto text-xs">
+                            {JSON.stringify(row.original, null, 2)}
+                          </pre>
+                        </td>
+                      </tr>
+                    ) : null}
+                  </Fragment>
+                );
+              })}
               {rows.length === 0 ? (
                 <tr>
                   <td className="px-4 py-2 text-muted-foreground" colSpan={columns.length}>

--- a/frontend/app/(platform)/platform/admin/traffic/TrafficClient.tsx
+++ b/frontend/app/(platform)/platform/admin/traffic/TrafficClient.tsx
@@ -7,7 +7,6 @@ import {
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import { StatusBadge } from "@components/platform/widgets";
 import { useAdmin } from "../AdminOverviewClient";
 
 type RequestRow = {
@@ -27,6 +26,32 @@ type RequestRow = {
   table_name: string | null;
 };
 
+/** HTTP-code-aware status chip — StatusBadge's tone ladder only matches
+ *  workflow words (success/failure/running...), so every numeric status
+ *  falls through to the same neutral gray there. Same chip shape/classes,
+ *  bucketed by status-code class instead. Do not touch StatusBadge itself —
+ *  other pages depend on its word ladder. */
+function HttpStatusBadge({ status }: { status: number | null | undefined }) {
+  if (status == null) return <span className="text-xs text-muted-foreground">–</span>;
+  const tone =
+    status >= 200 && status < 300
+      ? "bg-status-success/15 text-status-success-ink dark:text-status-success"
+      : status >= 300 && status < 400
+        ? "bg-status-scheduled/15 text-status-scheduled-ink dark:text-status-scheduled"
+        : status >= 400 && status < 500
+          ? "bg-status-running/15 text-status-running-ink dark:text-status-running"
+          : status >= 500
+            ? "bg-status-failed/15 text-status-failed-ink dark:text-status-failed"
+            : "bg-status-cancelled/20 text-status-cancelled-ink dark:text-status-cancelled";
+  return (
+    <span
+      className={`inline-block rounded-full px-2 py-0.5 font-mono text-xs font-semibold uppercase tracking-wide ${tone}`}
+    >
+      {status}
+    </span>
+  );
+}
+
 const columnHelper = createColumnHelper<RequestRow>();
 const columns = [
   columnHelper.accessor("ts", {
@@ -40,7 +65,7 @@ const columns = [
   }),
   columnHelper.accessor("status", {
     header: "Status",
-    cell: (c) => <StatusBadge status={String(c.getValue())} />,
+    cell: (c) => <HttpStatusBadge status={c.getValue()} />,
   }),
   columnHelper.accessor("duration_ms", {
     header: "Duration",

--- a/frontend/app/(platform)/platform/admin/traffic/TrafficClient.tsx
+++ b/frontend/app/(platform)/platform/admin/traffic/TrafficClient.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { Fragment, useMemo, useState } from "react";
+import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { StatusBadge } from "@components/platform/widgets";
+import { useAdmin } from "../AdminOverviewClient";
+
+type RequestRow = {
+  ts: string;
+  service: string;
+  method: string;
+  path: string;
+  route_pattern: string;
+  status: number;
+  duration_ms: number;
+  key_id: string | null;
+  ip: string | null;
+  ua: string | null;
+  referrer: string | null;
+  bytes_out: number | null;
+  schema_name: string | null;
+  table_name: string | null;
+};
+
+const columnHelper = createColumnHelper<RequestRow>();
+const columns = [
+  columnHelper.accessor("ts", {
+    header: "Time",
+    cell: (c) => <span className="font-mono text-xs">{c.getValue()}</span>,
+  }),
+  columnHelper.accessor("method", { header: "Method" }),
+  columnHelper.accessor("path", {
+    header: "Path",
+    cell: (c) => <span className="font-mono text-xs">{c.getValue()}</span>,
+  }),
+  columnHelper.accessor("status", {
+    header: "Status",
+    cell: (c) => <StatusBadge status={String(c.getValue())} />,
+  }),
+  columnHelper.accessor("duration_ms", {
+    header: "Duration",
+    cell: (c) => `${Math.round(c.getValue())} ms`,
+  }),
+  columnHelper.accessor("key_id", { header: "Key" }),
+  columnHelper.accessor("ip", { header: "IP" }),
+];
+
+export default function TrafficClient() {
+  const [hours, setHours] = useState("24");
+  const [status, setStatus] = useState("");
+  const [keyId, setKeyId] = useState("");
+  const [pathPrefix, setPathPrefix] = useState("");
+  const [service, setService] = useState("");
+  const [expanded, setExpanded] = useState<number | null>(null);
+
+  const qs = useMemo(() => {
+    const p = new URLSearchParams({ hours, limit: "200" });
+    if (status) p.set("status", status);
+    if (keyId) p.set("key_id", keyId);
+    if (pathPrefix) p.set("path_prefix", pathPrefix);
+    if (service) p.set("service", service);
+    return `?${p.toString()}`;
+  }, [hours, status, keyId, pathPrefix, service]);
+
+  const { data, error } = useAdmin<{ rows: RequestRow[] }>("requests", qs);
+  const rows = data?.rows ?? [];
+
+  const table = useReactTable({
+    data: rows,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="mb-2 flex items-center justify-between gap-4">
+        <h1 className="font-display text-2xl font-bold tracking-tight">Traffic</h1>
+      </div>
+      <div className="flex flex-wrap items-end gap-3">
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          Hours
+          <input
+            value={hours}
+            onChange={(e) => setHours(e.target.value)}
+            className="w-20 rounded-md border border-input bg-card px-2 py-1 font-inter text-sm"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          Status
+          <input
+            value={status}
+            onChange={(e) => setStatus(e.target.value)}
+            placeholder="e.g. 500"
+            className="w-24 rounded-md border border-input bg-card px-2 py-1 font-inter text-sm"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          Service
+          <input
+            value={service}
+            onChange={(e) => setService(e.target.value)}
+            className="w-32 rounded-md border border-input bg-card px-2 py-1 font-inter text-sm"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          Key ID
+          <input
+            value={keyId}
+            onChange={(e) => setKeyId(e.target.value)}
+            className="w-32 rounded-md border border-input bg-card px-2 py-1 font-inter text-sm"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          Path prefix
+          <input
+            value={pathPrefix}
+            onChange={(e) => setPathPrefix(e.target.value)}
+            placeholder="/v1/..."
+            className="w-40 rounded-md border border-input bg-card px-2 py-1 font-inter text-sm"
+          />
+        </label>
+      </div>
+
+      {error ? (
+        <p className="text-sm text-muted-foreground">Couldn&apos;t load requests.</p>
+      ) : !data ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-border">
+          <table className="w-full text-left font-inter text-sm">
+            <thead className="bg-muted text-xs uppercase text-muted-foreground">
+              {table.getHeaderGroups().map((hg) => (
+                <tr key={hg.id}>
+                  {hg.headers.map((h) => (
+                    <th key={h.id} className="px-4 py-2">
+                      {flexRender(h.column.columnDef.header, h.getContext())}
+                    </th>
+                  ))}
+                </tr>
+              ))}
+            </thead>
+            <tbody>
+              {table.getRowModel().rows.map((row, i) => (
+                <Fragment key={row.id}>
+                  <tr
+                    onClick={() => setExpanded(expanded === i ? null : i)}
+                    className="cursor-pointer border-t border-border hover:bg-secondary/50"
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <td key={cell.id} className="px-4 py-2">
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </td>
+                    ))}
+                  </tr>
+                  {expanded === i ? (
+                    <tr className="border-t border-border bg-secondary/30">
+                      <td colSpan={columns.length} className="px-4 py-2">
+                        <pre className="overflow-x-auto text-xs">
+                          {JSON.stringify(row.original, null, 2)}
+                        </pre>
+                      </td>
+                    </tr>
+                  ) : null}
+                </Fragment>
+              ))}
+              {rows.length === 0 ? (
+                <tr>
+                  <td className="px-4 py-2 text-muted-foreground" colSpan={columns.length}>
+                    No requests in this window.
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/(platform)/platform/admin/traffic/page.tsx
+++ b/frontend/app/(platform)/platform/admin/traffic/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next";
+import TrafficClient from "./TrafficClient";
+
+export const metadata: Metadata = { title: "Traffic" };
+
+export default function PlatformAdminTrafficPage() {
+  return <TrafficClient />;
+}

--- a/frontend/app/(platform)/platform/layout.tsx
+++ b/frontend/app/(platform)/platform/layout.tsx
@@ -32,7 +32,7 @@ export default async function PlatformLayout({
         <PlatformTopbar login={session.login ?? null} isAdmin={isAdmin} />
         <main className="min-w-0 flex-1 px-6 py-6">{children}</main>
       </div>
-      <CommandMenu />
+      <CommandMenu isAdmin={isAdmin} />
       <PlatformBeacon login={session.login ?? null} />
     </div>
   );

--- a/frontend/app/(platform)/platform/layout.tsx
+++ b/frontend/app/(platform)/platform/layout.tsx
@@ -4,6 +4,7 @@ import SignInGate from "@components/platform/SignInGate";
 import PlatformSidebar from "@components/platform/PlatformSidebar";
 import PlatformTopbar from "@components/platform/PlatformTopbar";
 import CommandMenu from "@components/platform/CommandMenu";
+import PlatformBeacon from "@components/platform/PlatformBeacon";
 
 export const metadata: Metadata = {
   title: { default: "Platform", template: "%s · SDV Platform" },
@@ -31,6 +32,7 @@ export default async function PlatformLayout({
         <main className="min-w-0 flex-1 px-6 py-6">{children}</main>
       </div>
       <CommandMenu />
+      <PlatformBeacon login={session.login ?? null} />
     </div>
   );
 }

--- a/frontend/app/(platform)/platform/layout.tsx
+++ b/frontend/app/(platform)/platform/layout.tsx
@@ -24,11 +24,12 @@ export default async function PlatformLayout({
     return <SignInGate signedIn={Boolean(session)} />;
   }
 
+  const isAdmin = session.role === "admin";
   return (
     <div className="flex min-h-dvh">
-      <PlatformSidebar />
+      <PlatformSidebar isAdmin={isAdmin} />
       <div className="flex min-w-0 flex-1 flex-col">
-        <PlatformTopbar login={session.login ?? null} />
+        <PlatformTopbar login={session.login ?? null} isAdmin={isAdmin} />
         <main className="min-w-0 flex-1 px-6 py-6">{children}</main>
       </div>
       <CommandMenu />

--- a/frontend/app/api/beacon/route.ts
+++ b/frontend/app/api/beacon/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { requireMemberApp } from "@lib/platform/auth";
+
+const BASE = process.env.SDV_DATA_API_URL ?? "https://data.sportsdataverse.org";
+
+/** Forwards platform beacon batches to the Data API ingest (fail-open). */
+export async function POST(req: Request) {
+  const { deny } = await requireMemberApp();
+  if (deny) return deny;
+
+  const key = process.env.SDV_INGEST_KEY;
+  if (!key) return NextResponse.json({ success: false }, { status: 503 });
+
+  try {
+    const body = await req.text();
+    await fetch(`${BASE}/v1/ingest`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-SDV-Ingest-Key": key,
+      },
+      body,
+      signal: AbortSignal.timeout(3000),
+    });
+  } catch {
+    /* fail-open: never surface ingest failures to the client */
+  }
+
+  return NextResponse.json({ success: true }, { status: 202 });
+}

--- a/frontend/app/api/beacon/route.ts
+++ b/frontend/app/api/beacon/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { requireMemberApp } from "@lib/platform/auth";
+import { isHttpsBase, requireMemberApp } from "@lib/platform/auth";
 
 const BASE = process.env.SDV_DATA_API_URL ?? "https://data.sportsdataverse.org";
 
@@ -9,7 +9,7 @@ export async function POST(req: Request) {
   if (deny) return deny;
 
   const key = process.env.SDV_INGEST_KEY;
-  if (!key) return NextResponse.json({ success: false }, { status: 503 });
+  if (!key || !isHttpsBase(BASE)) return NextResponse.json({ success: false }, { status: 503 });
 
   try {
     const body = await req.text();

--- a/frontend/app/api/platform/admin/[name]/route.ts
+++ b/frontend/app/api/platform/admin/[name]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { requireAdminApp } from "@lib/platform/auth";
+import { isHttpsBase, requireAdminApp } from "@lib/platform/auth";
 
 /** Server-side proxy to the Data API admin endpoints — the admin key never
  *  reaches the browser. Query params pass through verbatim. */
@@ -21,7 +21,7 @@ export async function GET(req: Request, ctx: Ctx) {
     );
   }
   const key = process.env.SDV_DATA_ADMIN_KEY;
-  if (!key) {
+  if (!key || !isHttpsBase(BASE)) {
     return NextResponse.json(
       { message: "admin key not configured", success: false },
       { status: 503 }

--- a/frontend/app/api/platform/admin/[name]/route.ts
+++ b/frontend/app/api/platform/admin/[name]/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { requireAdminApp } from "@lib/platform/auth";
+
+/** Server-side proxy to the Data API admin endpoints — the admin key never
+ *  reaches the browser. Query params pass through verbatim. */
+
+const BASE =
+  process.env.SDV_DATA_API_URL ?? "https://data.sportsdataverse.org";
+const NAMES = new Set(["summary", "requests", "keys", "errors", "site"]);
+
+type Ctx = { params: Promise<{ name: string }> };
+
+export async function GET(req: Request, ctx: Ctx) {
+  const { deny } = await requireAdminApp();
+  if (deny) return deny;
+  const { name } = await ctx.params;
+  if (!NAMES.has(name)) {
+    return NextResponse.json(
+      { message: "unknown panel", success: false },
+      { status: 404 }
+    );
+  }
+  const key = process.env.SDV_DATA_ADMIN_KEY;
+  if (!key) {
+    return NextResponse.json(
+      { message: "admin key not configured", success: false },
+      { status: 503 }
+    );
+  }
+  const qs = new URL(req.url).search;
+  try {
+    const upstream = await fetch(`${BASE}/v1/admin/${name}${qs}`, {
+      headers: { Authorization: `Bearer ${key}` },
+      signal: AbortSignal.timeout(10_000),
+      cache: "no-store",
+    });
+    return NextResponse.json(await upstream.json(), {
+      status: upstream.status,
+    });
+  } catch {
+    return NextResponse.json(
+      { message: "data api unreachable", success: false },
+      { status: 502 }
+    );
+  }
+}

--- a/frontend/components/platform/CommandMenu.tsx
+++ b/frontend/components/platform/CommandMenu.tsx
@@ -41,7 +41,11 @@ export default function CommandMenu() {
 
   const go = (href: string) => {
     setOpen(false);
-    router.push(href);
+    if (href.startsWith("http")) {
+      window.open(href, "_blank", "noopener");
+    } else {
+      router.push(href);
+    }
   };
 
   return (

--- a/frontend/components/platform/CommandMenu.tsx
+++ b/frontend/components/platform/CommandMenu.tsx
@@ -19,7 +19,7 @@ export function openCommandMenu() {
   window.dispatchEvent(new Event(OPEN_EVENT));
 }
 
-export default function CommandMenu() {
+export default function CommandMenu({ isAdmin = false }: { isAdmin?: boolean }) {
   const [open, setOpen] = useState(false);
   const router = useRouter();
 
@@ -54,7 +54,7 @@ export default function CommandMenu() {
       <CommandList>
         <CommandEmpty>No results.</CommandEmpty>
         <CommandGroup heading="Platform">
-          {PLATFORM_TABS.map((tab) => (
+          {PLATFORM_TABS.filter((tab) => !tab.adminOnly || isAdmin).map((tab) => (
             <CommandItem key={tab.href} onSelect={() => go(tab.href)}>
               {tab.label}
             </CommandItem>

--- a/frontend/components/platform/PlatformBeacon.tsx
+++ b/frontend/components/platform/PlatformBeacon.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+import { useReportWebVitals } from "next/web-vitals";
+import { flush, setLogin, track } from "@lib/platform/beacon";
+
+export default function PlatformBeacon({ login }: { login: string | null }) {
+  const pathname = usePathname();
+
+  useEffect(() => setLogin(login), [login]);
+
+  useEffect(() => {
+    if (pathname) track("pageview", { path: pathname });
+  }, [pathname]);
+
+  useReportWebVitals((m) =>
+    track("web_vital", { name: m.name, value: m.value })
+  );
+
+  useEffect(() => {
+    const onErr = (e: ErrorEvent) =>
+      track("js_error", { name: String(e.message).slice(0, 300) });
+    const onRej = (e: PromiseRejectionEvent) =>
+      track("js_error", { name: String(e.reason).slice(0, 300) });
+    window.addEventListener("error", onErr);
+    window.addEventListener("unhandledrejection", onRej);
+    return () => {
+      window.removeEventListener("error", onErr);
+      window.removeEventListener("unhandledrejection", onRej);
+      flush();
+    };
+  }, []);
+
+  return null;
+}

--- a/frontend/components/platform/PlatformSidebar.tsx
+++ b/frontend/components/platform/PlatformSidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, ExternalLink } from "lucide-react";
 import { cn } from "@lib/utils";
 import { PLATFORM_NAV } from "./widgets";
 
@@ -24,8 +24,25 @@ export function PlatformNavList({ onNavigate }: { onNavigate?: () => void }) {
           ) : null}
           <ul className="space-y-0.5">
             {g.items.map((item) => {
-              const active = isPlatformActive(pathname, item.href);
               const Icon = item.icon;
+              if (item.external) {
+                return (
+                  <li key={item.href}>
+                    <a
+                      href={item.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={onNavigate}
+                      className="flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+                    >
+                      <Icon className="size-4 shrink-0" />
+                      {item.label}
+                      <ExternalLink className="ml-auto size-3 opacity-60" />
+                    </a>
+                  </li>
+                );
+              }
+              const active = isPlatformActive(pathname, item.href);
               return (
                 <li key={item.href}>
                   <Link

--- a/frontend/components/platform/PlatformSidebar.tsx
+++ b/frontend/components/platform/PlatformSidebar.tsx
@@ -11,11 +11,20 @@ export function isPlatformActive(pathname: string, href: string): boolean {
 }
 
 /** Shared grouped nav list — used by the desktop sidebar and the mobile drawer. */
-export function PlatformNavList({ onNavigate }: { onNavigate?: () => void }) {
+export function PlatformNavList({
+  onNavigate,
+  isAdmin = false,
+}: {
+  onNavigate?: () => void;
+  isAdmin?: boolean;
+}) {
   const pathname = usePathname() ?? "";
   return (
     <nav className="flex-1 overflow-y-auto px-2 py-3">
-      {PLATFORM_NAV.map((g, gi) => (
+      {PLATFORM_NAV.map((g, gi) => {
+        const items = g.items.filter((i) => !i.adminOnly || isAdmin);
+        if (items.length === 0) return null;
+        return (
         <div key={gi} className={cn(gi > 0 && "mt-5")}>
           {g.title ? (
             <p className="px-2 pb-1.5 font-display text-xs font-bold uppercase tracking-widest text-muted-foreground">
@@ -23,7 +32,7 @@ export function PlatformNavList({ onNavigate }: { onNavigate?: () => void }) {
             </p>
           ) : null}
           <ul className="space-y-0.5">
-            {g.items.map((item) => {
+            {items.map((item) => {
               const Icon = item.icon;
               if (item.external) {
                 return (
@@ -62,12 +71,13 @@ export function PlatformNavList({ onNavigate }: { onNavigate?: () => void }) {
             })}
           </ul>
         </div>
-      ))}
+        );
+      })}
     </nav>
   );
 }
 
-export default function PlatformSidebar() {
+export default function PlatformSidebar({ isAdmin = false }: { isAdmin?: boolean }) {
   return (
     <aside className="sticky top-0 z-30 hidden h-dvh w-56 shrink-0 flex-col border-r border-border bg-card md:flex">
       <div className="flex h-12 items-center gap-2 border-b border-border px-4">
@@ -76,7 +86,7 @@ export default function PlatformSidebar() {
           Platform
         </span>
       </div>
-      <PlatformNavList />
+      <PlatformNavList isAdmin={isAdmin} />
       <div className="border-t border-border p-2">
         <Link
           href="/"

--- a/frontend/components/platform/PlatformTopbar.tsx
+++ b/frontend/components/platform/PlatformTopbar.tsx
@@ -32,7 +32,13 @@ function crumbFor(pathname: string): string {
   return tab?.label ?? "Platform";
 }
 
-export default function PlatformTopbar({ login }: { login: string | null }) {
+export default function PlatformTopbar({
+  login,
+  isAdmin = false,
+}: {
+  login: string | null;
+  isAdmin?: boolean;
+}) {
   const pathname = usePathname() ?? "/platform";
   const { resolvedTheme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
@@ -51,7 +57,7 @@ export default function PlatformTopbar({ login }: { login: string | null }) {
           <SheetTitle className="px-4 font-display text-sm font-bold uppercase tracking-wide">
             SDV Platform
           </SheetTitle>
-          <PlatformNavList onNavigate={() => setMenuOpen(false)} />
+          <PlatformNavList onNavigate={() => setMenuOpen(false)} isAdmin={isAdmin} />
         </SheetContent>
       </Sheet>
 

--- a/frontend/components/platform/widgets.tsx
+++ b/frontend/components/platform/widgets.tsx
@@ -16,12 +16,14 @@ import {
   HardDrive,
   KeyRound,
   Package,
+  FileCode2,
 } from "lucide-react";
 
 export type PlatformNavItem = {
   href: string;
   label: string;
   icon: React.ComponentType<{ className?: string }>;
+  external?: boolean;
 };
 
 /** THE platform nav — single source for the sidebar, the mobile drawer, the
@@ -63,6 +65,7 @@ export const PLATFORM_NAV: { title: string | null; items: PlatformNavItem[] }[] 
     items: [
       { href: "/platform/database", label: "Database", icon: HardDrive },
       { href: "/platform/api-key", label: "API Key", icon: KeyRound },
+      { href: "https://data.sportsdataverse.org/docs", label: "API Docs", icon: FileCode2, external: true },
     ],
   },
 ];

--- a/frontend/components/platform/widgets.tsx
+++ b/frontend/components/platform/widgets.tsx
@@ -17,6 +17,7 @@ import {
   KeyRound,
   Package,
   FileCode2,
+  Gauge,
 } from "lucide-react";
 
 export type PlatformNavItem = {
@@ -24,6 +25,7 @@ export type PlatformNavItem = {
   label: string;
   icon: React.ComponentType<{ className?: string }>;
   external?: boolean;
+  adminOnly?: boolean;
 };
 
 /** THE platform nav — single source for the sidebar, the mobile drawer, the
@@ -65,6 +67,7 @@ export const PLATFORM_NAV: { title: string | null; items: PlatformNavItem[] }[] 
     items: [
       { href: "/platform/database", label: "Database", icon: HardDrive },
       { href: "/platform/api-key", label: "API Key", icon: KeyRound },
+      { href: "/platform/admin", label: "Admin", icon: Gauge, adminOnly: true },
       { href: "https://data.sportsdataverse.org/docs", label: "API Docs", icon: FileCode2, external: true },
     ],
   },

--- a/frontend/components/platform/widgets.tsx
+++ b/frontend/components/platform/widgets.tsx
@@ -73,9 +73,11 @@ export const PLATFORM_NAV: { title: string | null; items: PlatformNavItem[] }[] 
   },
 ];
 
-/** Flat view of PLATFORM_NAV (⌘K palette, crumb resolution, legacy consumers). */
+/** Flat view of PLATFORM_NAV (⌘K palette, crumb resolution, legacy consumers).
+ *  Keeps `adminOnly` so consumers (the ⌘K palette) can filter it out for
+ *  non-admins instead of routing them into the denial card. */
 export const PLATFORM_TABS = PLATFORM_NAV.flatMap((g) =>
-  g.items.map(({ href, label }) => ({ href, label }))
+  g.items.map(({ href, label, adminOnly }) => ({ href, label, adminOnly }))
 );
 
 /** Colored chip for workflow conclusions / run statuses / booleans, on the

--- a/frontend/lib/platform/auth.ts
+++ b/frontend/lib/platform/auth.ts
@@ -107,6 +107,16 @@ export async function requireAdminApp(): Promise<{
  * (`req.headers.authorization`) and route handlers
  * (`req.headers.get("authorization")`) can use it.
  */
+/** Guards the admin/ingest proxies against sending a bearer key to a
+ *  plaintext endpoint — BASE can come from an env var, so don't trust it. */
+export function isHttpsBase(base: string): boolean {
+  try {
+    return new URL(base).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 export function checkIngestToken(header: string | null | undefined): boolean {
   const expected = process.env.PLATFORM_INGEST_TOKEN;
   if (!expected) return false;

--- a/frontend/lib/platform/auth.ts
+++ b/frontend/lib/platform/auth.ts
@@ -79,6 +79,28 @@ export async function requireMemberApp(): Promise<
 }
 
 /**
+ * Route-handler gate for /platform/admin: org member with the admin role.
+ * Mirrors `requireMemberApp`'s `{ session, deny }` shape.
+ */
+export async function requireAdminApp(): Promise<{
+  session: (Session & { login?: string | null }) | null;
+  deny: NextResponse | null;
+}> {
+  const { session, deny } = await requireMemberApp();
+  if (deny) return { session, deny };
+  if (session.role !== "admin") {
+    return {
+      session,
+      deny: NextResponse.json(
+        { message: "Admin role required.", success: false },
+        { status: 403 }
+      ),
+    };
+  }
+  return { session, deny: null };
+}
+
+/**
  * CI ingest auth: `Authorization: Bearer <PLATFORM_INGEST_TOKEN>`.
  * Fails closed when the env var is unset. Timing-safe comparison.
  * Accepts the raw Authorization header value so both Pages API routes

--- a/frontend/lib/platform/beacon.ts
+++ b/frontend/lib/platform/beacon.ts
@@ -1,0 +1,56 @@
+// Client-side telemetry queue for the /platform area. Fire-and-forget:
+// a dead ingest path must never affect the UI (errors swallowed).
+type EventType = "pageview" | "platform_action" | "web_vital" | "js_error";
+type BeaconEvent = { table: "client_event"; row: Record<string, unknown> };
+
+const queue: BeaconEvent[] = [];
+let login: string | null = null;
+
+export function setLogin(l: string | null) {
+  login = l;
+}
+
+export function track(
+  type: EventType,
+  fields: { name?: string; value?: number; path?: string } = {}
+) {
+  queue.push({
+    table: "client_event",
+    row: {
+      type,
+      name: fields.name ?? null,
+      value: fields.value ?? null,
+      path: fields.path ?? (typeof window !== "undefined" ? window.location.pathname : null),
+      login,
+    },
+  });
+  if (queue.length >= 10) flush();
+}
+
+export function flush() {
+  if (queue.length === 0) return;
+  const body = JSON.stringify({ events: queue.splice(0, queue.length) });
+  try {
+    if (
+      !navigator.sendBeacon?.(
+        "/api/beacon",
+        new Blob([body], { type: "application/json" })
+      )
+    ) {
+      fetch("/api/beacon", {
+        method: "POST",
+        body,
+        keepalive: true,
+        headers: { "content-type": "application/json" },
+      }).catch(() => {});
+    }
+  } catch {
+    /* fail-open */
+  }
+}
+
+if (typeof document !== "undefined") {
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") flush();
+  });
+}


### PR DESCRIPTION
Web side of the platform observability build (spec + plan live in sdv-db: docs/platform/2026-08-03-platform-observability-predictions-design.md; API counterpart: sportsdataverse/sdv-db#32).

## What's here
- **API Docs link**: sidebar (System group) + ⌘K palette entry → data.sportsdataverse.org/docs (external, new tab).
- **Telemetry beacon** (platform area only): pageviews, Web Vitals, JS errors → `/api/beacon` (member-gated) → Data API `/v1/ingest` with the server-held ingest key. Fully fail-open — a dead ingest path never affects the UI; SSR-safe.
- **Admin gate + proxy**: `requireAdminApp()` (org role `admin` via existing session plumbing); `/api/platform/admin/[name]` allowlisted server proxy — `SDV_DATA_ADMIN_KEY` never reaches the browser, gate runs before key/env logic so non-admins can't probe config.
- **`/platform/admin` dashboard** (admin-only nav entry + role-gated layout): Overview (req/error-rate/active-keys/slowest-p99 tiles + sparkline + top endpoints + latency p50/p95/p99), Traffic (filterable react-table, HTTP-class status chips, expandable row detail), Keys (per-key usage), Errors (grouped, expandable stacks), Site (pageviews, API referrers, Web Vitals p75, platform actions). SWR 30s refresh; no new dependencies.

## New Vercel env vars (production)
- `SDV_INGEST_KEY` — shared secret for the Data API ingest (same value as the API service unit)
- `SDV_DATA_ADMIN_KEY` — admin-scope Data API key for the dashboard proxy
- (`SDV_DATA_API_URL` optional override, defaults to https://data.sportsdataverse.org)
Note: `.env.example` doesn't list SDV_* vars (pre-existing repo convention gap).

## Verification
`npm run tsc` and `npm run lint` clean; dashboard field accesses verified against the API's typed response models; admin nav threading covers desktop sidebar + mobile drawer.

## Summary by Sourcery

Introduce an admin-only observability dashboard for the platform area, wired to Data API admin endpoints and backed by a new telemetry beacon for client-side metrics and errors.

New Features:
- Add an admin-gated /platform/admin dashboard with overview, traffic, keys, errors, and site tabs powered by server-proxied Data API admin endpoints.
- Add a client-side telemetry beacon for the platform area to send pageviews, web vitals, and JavaScript errors to the backend ingest API.
- Add an API Docs entry to the platform navigation and command palette that opens the external documentation site in a new tab.

Enhancements:
- Extend platform navigation and layout to respect the user’s admin role, hiding admin-only items for non-admins and surfacing an Admin tab for eligible users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin dashboard with Overview, Traffic, Keys, Errors, and Site sections.
  * Added request analytics, error details, API key usage, site metrics, Web Vitals, and filtering tools.
  * Added automatic platform telemetry for pageviews, performance metrics, and client-side errors.
  * Added role-based administrative navigation and protected admin access.
  * Added secure external-link handling and API documentation navigation.
* **Improvements**
  * Enhanced command navigation to open external URLs in new tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->