### PR TITLE
feat(platform): serve the API reference behind org sign-in

### DIFF
--- a/frontend/app/(platform)/platform/api-docs/ApiDocsClient.tsx
+++ b/frontend/app/(platform)/platform/api-docs/ApiDocsClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { KeyRound } from "lucide-react";
 
@@ -16,25 +16,33 @@ import "./swagger-theme.css";
  * directly — the reader supplies their own key via Authorize.
  */
 export default function ApiDocsClient() {
-  const mounted = useRef(false);
   const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
 
   useEffect(() => {
-    // React 18+ StrictMode double-invokes effects in dev; Swagger UI would
-    // otherwise mount twice into the same node.
-    if (mounted.current) return;
-    mounted.current = true;
+    const controller = new AbortController();
 
-    let cancelled = false;
     void (async () => {
       try {
-        const { default: SwaggerUIBundle } = await import(
-          "swagger-ui-dist/swagger-ui-es-bundle.js"
-        );
-        if (cancelled) return;
+        // Fetch the spec ourselves rather than handing Swagger UI a URL: its
+        // onComplete only fires once a spec parses, so a 502 from the proxy
+        // would otherwise leave this page spinning with no way to report it.
+        const [{ default: SwaggerUIBundle }, resp] = await Promise.all([
+          import("swagger-ui-dist/swagger-ui-es-bundle.js"),
+          fetch("/api/platform/openapi", { signal: controller.signal }),
+        ]);
+        if (!resp.ok) throw new Error(`spec request failed: ${resp.status}`);
+        const spec = await resp.json();
+        if (controller.signal.aborted) return;
+
+        const node = document.getElementById("swagger-ui");
+        if (!node) return;
+        // StrictMode re-runs this effect in dev; start from a clean node so the
+        // second pass replaces the first render instead of appending to it.
+        node.replaceChildren();
+
         SwaggerUIBundle({
-          url: "/api/platform/openapi",
-          domNode: document.getElementById("swagger-ui"),
+          spec,
+          domNode: node,
           presets: [SwaggerUIBundle.presets.apis],
           layout: "BaseLayout",
           docExpansion: "none",
@@ -45,16 +53,14 @@ export default function ApiDocsClient() {
           // 338 endpoints, some with 300+ column schemas — deep-expanding models
           // by default makes the page unusable.
           defaultModelExpandDepth: 1,
-          onComplete: () => !cancelled && setStatus("ready"),
         });
+        setStatus("ready");
       } catch {
-        if (!cancelled) setStatus("error");
+        if (!controller.signal.aborted) setStatus("error");
       }
     })();
 
-    return () => {
-      cancelled = true;
-    };
+    return () => controller.abort();
   }, []);
 
   return (
@@ -66,7 +72,7 @@ export default function ApiDocsClient() {
         <Link href="/platform/api-key" className="font-medium text-primary hover:underline">
           your API key page
         </Link>
-        .
+        — it stays in this browser until you clear it.
       </p>
 
       {status === "loading" ? (

--- a/frontend/app/(platform)/platform/api-docs/ApiDocsClient.tsx
+++ b/frontend/app/(platform)/platform/api-docs/ApiDocsClient.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { KeyRound } from "lucide-react";
+
+import "swagger-ui-dist/swagger-ui.css";
+import "./swagger-theme.css";
+
+/**
+ * Swagger UI over the member-gated spec proxy.
+ *
+ * The bundle is imported dynamically so ~1 MB of vendor JS is code-split to this
+ * route and never runs during SSR (it touches `window` at module scope). The
+ * spec's `servers` entry points at the Data API, so "try it out" calls it
+ * directly — the reader supplies their own key via Authorize.
+ */
+export default function ApiDocsClient() {
+  const mounted = useRef(false);
+  const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
+
+  useEffect(() => {
+    // React 18+ StrictMode double-invokes effects in dev; Swagger UI would
+    // otherwise mount twice into the same node.
+    if (mounted.current) return;
+    mounted.current = true;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const { default: SwaggerUIBundle } = await import(
+          "swagger-ui-dist/swagger-ui-es-bundle.js"
+        );
+        if (cancelled) return;
+        SwaggerUIBundle({
+          url: "/api/platform/openapi",
+          domNode: document.getElementById("swagger-ui"),
+          presets: [SwaggerUIBundle.presets.apis],
+          layout: "BaseLayout",
+          docExpansion: "none",
+          filter: true,
+          persistAuthorization: true,
+          tryItOutEnabled: true,
+          defaultModelsExpandDepth: -1,
+          // 338 endpoints, some with 300+ column schemas — deep-expanding models
+          // by default makes the page unusable.
+          defaultModelExpandDepth: 1,
+          onComplete: () => !cancelled && setStatus("ready"),
+        });
+      } catch {
+        if (!cancelled) setStatus("error");
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="flex flex-wrap items-center gap-1.5 text-sm text-muted-foreground">
+        <KeyRound className="size-4 shrink-0" />
+        To run a request, click <span className="font-medium text-foreground">Authorize</span> and
+        paste a key from
+        <Link href="/platform/api-key" className="font-medium text-primary hover:underline">
+          your API key page
+        </Link>
+        .
+      </p>
+
+      {status === "loading" ? (
+        <p className="text-sm text-muted-foreground">Loading the reference (the spec is ~6 MB)…</p>
+      ) : null}
+      {status === "error" ? (
+        <div className="rounded-lg border border-border bg-card p-4">
+          <p className="font-display text-sm font-bold uppercase tracking-wide">
+            Couldn’t load the reference
+          </p>
+          <p className="mt-2 text-sm text-muted-foreground">
+            The Data API may be unreachable, or this deployment is missing its API key. The
+            committed spec is always available in the{" "}
+            <a
+              href="https://github.com/sportsdataverse/sdv-db/blob/main/docs/sdv-data-api.openapi.json"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-primary hover:underline"
+            >
+              sdv-db repo
+            </a>
+            .
+          </p>
+        </div>
+      ) : null}
+
+      <div id="swagger-ui" />
+    </div>
+  );
+}

--- a/frontend/app/(platform)/platform/api-docs/page.tsx
+++ b/frontend/app/(platform)/platform/api-docs/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import ApiDocsClient from "./ApiDocsClient";
+
+export const metadata: Metadata = { title: "API docs" };
+
+export default function ApiDocsPage() {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="mb-0">
+        <h1 className="font-display text-2xl font-bold tracking-tight">API docs</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Interactive reference for the SportsDataverse Data API, for org members.
+        </p>
+      </div>
+      <ApiDocsClient />
+    </div>
+  );
+}

--- a/frontend/app/(platform)/platform/api-docs/swagger-theme.css
+++ b/frontend/app/(platform)/platform/api-docs/swagger-theme.css
@@ -1,0 +1,108 @@
+/*
+ * Swagger UI wearing the platform's design tokens.
+ *
+ * A blend layer, not a full re-skin: it maps the surfaces a reader actually
+ * looks at (text, cards, tables, inputs, the Authorize bar) onto our CSS
+ * variables so the page works in both themes, and leaves Swagger's method
+ * colors and response highlighting alone. Every rule is scoped under
+ * #swagger-ui, so nothing here can leak into the rest of the platform.
+ */
+
+#swagger-ui .swagger-ui {
+  font-family: inherit;
+  color: var(--foreground);
+}
+
+#swagger-ui .swagger-ui .info .title,
+#swagger-ui .swagger-ui .info li,
+#swagger-ui .swagger-ui .info p,
+#swagger-ui .swagger-ui .info table,
+#swagger-ui .swagger-ui .opblock-tag,
+#swagger-ui .swagger-ui .opblock .opblock-summary-path,
+#swagger-ui .swagger-ui .opblock .opblock-summary-path__deprecated,
+#swagger-ui .swagger-ui table thead tr td,
+#swagger-ui .swagger-ui table thead tr th,
+#swagger-ui .swagger-ui .parameter__name,
+#swagger-ui .swagger-ui .parameter__type,
+#swagger-ui .swagger-ui .response-col_status,
+#swagger-ui .swagger-ui .response-col_links,
+#swagger-ui .swagger-ui .tab li,
+#swagger-ui .swagger-ui .tab li button.tablinks,
+#swagger-ui .swagger-ui label,
+#swagger-ui .swagger-ui .model-title,
+#swagger-ui .swagger-ui .model,
+#swagger-ui .swagger-ui .dialog-ux .modal-ux-header h3,
+#swagger-ui .swagger-ui .dialog-ux .modal-ux-content h4,
+#swagger-ui .swagger-ui .dialog-ux .modal-ux-content p {
+  color: var(--foreground);
+}
+
+#swagger-ui .swagger-ui .opblock .opblock-summary-description,
+#swagger-ui .swagger-ui .opblock-description-wrapper p,
+#swagger-ui .swagger-ui .renderedMarkdown p,
+#swagger-ui .swagger-ui .parameter__in,
+#swagger-ui .swagger-ui .parameter__extension,
+#swagger-ui .swagger-ui .opblock-external-docs-wrapper p {
+  color: var(--muted-foreground);
+}
+
+/* Surfaces */
+#swagger-ui .swagger-ui .opblock,
+#swagger-ui .swagger-ui .opblock .opblock-section-header,
+#swagger-ui .swagger-ui section.models,
+#swagger-ui .swagger-ui section.models .model-container,
+#swagger-ui .swagger-ui .model-box,
+#swagger-ui .swagger-ui .scheme-container,
+#swagger-ui .swagger-ui .dialog-ux .modal-ux {
+  background: var(--card);
+  border-color: var(--border);
+  box-shadow: none;
+}
+
+#swagger-ui .swagger-ui .opblock-tag,
+#swagger-ui .swagger-ui table tbody tr td {
+  border-color: var(--border);
+}
+
+/* Form controls: Swagger ships light-only inputs, unreadable in dark. */
+#swagger-ui .swagger-ui input[type="text"],
+#swagger-ui .swagger-ui input[type="password"],
+#swagger-ui .swagger-ui input[type="email"],
+#swagger-ui .swagger-ui input[type="search"],
+#swagger-ui .swagger-ui textarea,
+#swagger-ui .swagger-ui select {
+  background: var(--background);
+  border-color: var(--border);
+  color: var(--foreground);
+}
+
+#swagger-ui .swagger-ui .btn {
+  border-color: var(--border);
+  color: var(--foreground);
+}
+
+#swagger-ui .swagger-ui .btn.authorize,
+#swagger-ui .swagger-ui .btn.execute {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: var(--primary-foreground);
+}
+
+#swagger-ui .swagger-ui .btn.authorize svg {
+  fill: var(--primary-foreground);
+}
+
+/* Chevrons and expand/collapse affordances are baked-in dark glyphs; flip them
+ * in dark mode so they don't disappear against the card. */
+.dark #swagger-ui .swagger-ui .opblock-summary-control svg,
+.dark #swagger-ui .swagger-ui .expand-operation svg,
+.dark #swagger-ui .swagger-ui .models-control svg,
+.dark #swagger-ui .swagger-ui .model-toggle {
+  filter: invert(1);
+}
+
+/* The spec's own H2 duplicates the page heading; its base-url line stays, since
+ * that's where "try it out" actually sends requests. */
+#swagger-ui .swagger-ui .info .title {
+  display: none;
+}

--- a/frontend/app/api/platform/openapi/route.ts
+++ b/frontend/app/api/platform/openapi/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { isHttpsBase, requireMemberApp } from "@lib/platform/auth";
+
+/**
+ * Member-gated pass-through for the Data API's OpenAPI schema.
+ *
+ * The API stopped serving /openapi.json anonymously, so the docs page reads it
+ * through here: the key stays server-side and the spec only reaches signed-in
+ * org members. The upstream body (~6 MB) is streamed rather than parsed — this
+ * route never inspects it, so there's no reason to buffer it into the function.
+ *
+ * Reuses SDV_DATA_ADMIN_KEY (minted with read+admin scopes). Only ever sent to
+ * this one fixed path, so the extra scope is never exercised; a dedicated
+ * read-only key would work equally well if one is ever minted.
+ */
+
+const BASE = process.env.SDV_DATA_API_URL ?? "https://data.sportsdataverse.org";
+
+export async function GET() {
+  const { deny } = await requireMemberApp();
+  if (deny) return deny;
+  const key = process.env.SDV_DATA_ADMIN_KEY;
+  if (!key || !isHttpsBase(BASE)) {
+    return NextResponse.json(
+      { message: "data api key not configured", success: false },
+      { status: 503 }
+    );
+  }
+  try {
+    const upstream = await fetch(`${BASE}/openapi.json`, {
+      headers: { Authorization: `Bearer ${key}` },
+      signal: AbortSignal.timeout(20_000),
+      cache: "no-store",
+    });
+    if (!upstream.ok || !upstream.body) {
+      return NextResponse.json(
+        { message: "spec unavailable", success: false },
+        { status: upstream.status === 200 ? 502 : upstream.status }
+      );
+    }
+    return new NextResponse(upstream.body, {
+      status: 200,
+      headers: {
+        "content-type": "application/json",
+        // Per-viewer cache: the spec only changes when the API redeploys, and
+        // re-fetching 6 MB on every page view helps nobody.
+        "cache-control": "private, max-age=600",
+      },
+    });
+  } catch {
+    return NextResponse.json(
+      { message: "data api unreachable", success: false },
+      { status: 502 }
+    );
+  }
+}

--- a/frontend/app/api/platform/openapi/route.ts
+++ b/frontend/app/api/platform/openapi/route.ts
@@ -9,9 +9,9 @@ import { isHttpsBase, requireMemberApp } from "@lib/platform/auth";
  * org members. The upstream body (~6 MB) is streamed rather than parsed — this
  * route never inspects it, so there's no reason to buffer it into the function.
  *
- * Reuses SDV_DATA_ADMIN_KEY (minted with read+admin scopes). Only ever sent to
- * this one fixed path, so the extra scope is never exercised; a dedicated
- * read-only key would work equally well if one is ever minted.
+ * Fetching a spec needs nothing beyond `read`, so it prefers SDV_DATA_READ_KEY
+ * and falls back to the admin key only where no read key has been provisioned.
+ * Set the read key wherever this runs to keep admin scope out of this path.
  */
 
 const BASE = process.env.SDV_DATA_API_URL ?? "https://data.sportsdataverse.org";
@@ -19,10 +19,16 @@ const BASE = process.env.SDV_DATA_API_URL ?? "https://data.sportsdataverse.org";
 export async function GET() {
   const { deny } = await requireMemberApp();
   if (deny) return deny;
-  const key = process.env.SDV_DATA_ADMIN_KEY;
-  if (!key || !isHttpsBase(BASE)) {
+  const key = process.env.SDV_DATA_READ_KEY ?? process.env.SDV_DATA_ADMIN_KEY;
+  if (!key) {
     return NextResponse.json(
       { message: "data api key not configured", success: false },
+      { status: 503 }
+    );
+  }
+  if (!isHttpsBase(BASE)) {
+    return NextResponse.json(
+      { message: "SDV_DATA_API_URL must be https", success: false },
       { status: 503 }
     );
   }

--- a/frontend/components/platform/widgets.tsx
+++ b/frontend/components/platform/widgets.tsx
@@ -68,7 +68,7 @@ export const PLATFORM_NAV: { title: string | null; items: PlatformNavItem[] }[] 
       { href: "/platform/database", label: "Database", icon: HardDrive },
       { href: "/platform/api-key", label: "API Key", icon: KeyRound },
       { href: "/platform/admin", label: "Admin", icon: Gauge, adminOnly: true },
-      { href: "https://data.sportsdataverse.org/docs", label: "API Docs", icon: FileCode2, external: true },
+      { href: "/platform/api-docs", label: "API Docs", icon: FileCode2 },
     ],
   },
 ];

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -51,6 +51,7 @@
         "sharp": "^0.34.0",
         "shiki": "^1.29.2",
         "sonner": "^2.0.7",
+        "swagger-ui-dist": "^5.32.12",
         "swr": "^2.3.3",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
@@ -3393,6 +3394,13 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@shikijs/core": {
       "version": "1.29.2",
@@ -12319,6 +12327,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.12",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.12.tgz",
+      "integrity": "sha512-ceXE+KNc5LXafhh36trB6nxK+U2EIKUWzHT7sBiMosf2eJLAefalYnTwMouQBmSyED6m7Yz+GYZEcL+Glt3sww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/swr": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
     "sharp": "^0.34.0",
     "shiki": "^1.29.2",
     "sonner": "^2.0.7",
+    "swagger-ui-dist": "^5.32.12",
     "swr": "^2.3.3",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",

--- a/frontend/types/swagger-ui-dist.d.ts
+++ b/frontend/types/swagger-ui-dist.d.ts
@@ -1,0 +1,30 @@
+/**
+ * swagger-ui-dist ships no types. Rather than take on @types/swagger-ui-dist
+ * (which describes the whole plugin system), this declares exactly the surface
+ * the API docs page uses — extend it if that page starts using more.
+ */
+declare module "swagger-ui-dist/swagger-ui-es-bundle.js" {
+  type SwaggerUIConfig = {
+    url?: string;
+    spec?: object;
+    domNode?: HTMLElement | null;
+    dom_id?: string;
+    presets?: unknown[];
+    layout?: string;
+    docExpansion?: "list" | "full" | "none";
+    filter?: boolean | string;
+    persistAuthorization?: boolean;
+    tryItOutEnabled?: boolean;
+    defaultModelsExpandDepth?: number;
+    defaultModelExpandDepth?: number;
+    onComplete?: () => void;
+  };
+
+  interface SwaggerUIBundleStatic {
+    (config: SwaggerUIConfig): unknown;
+    presets: { apis: unknown };
+  }
+
+  const SwaggerUIBundle: SwaggerUIBundleStatic;
+  export default SwaggerUIBundle;
+}


### PR DESCRIPTION
Pairs with sportsdataverse/sdv-db#33. Requested: the docs page should require the same sign-in as the data platform.

## What changes
- **`/platform/api-docs`** — new member-gated page (inside the existing platform layout gate) rendering Swagger UI.
- **`/api/platform/openapi`** — member-gated proxy that streams the ~6 MB spec from the Data API with a server-held key; the key never reaches the browser. Reuses `SDV_DATA_ADMIN_KEY` (read+admin scoped, only ever sent to this one fixed path), so **no new env vars**.
- Sidebar/⌘K "API Docs" entry switches from the external `data.sportsdataverse.org/docs` URL to the internal page.
- Try-it-out works: the spec now declares the API as its server (sdv-db#33) and the API allows this origin via CORS. Readers authorize with their own key from `/platform/api-key`.

## Why swagger-ui-dist instead of a CDN
No external script enters the app, nothing to keep SRI-pinned, and it works if a CSP is ever added. It's code-split to this route (a 1.4 MB chunk that no other page loads). `swagger-ui-dist` is the plain asset package — no React peer dependency, so nothing conflicts with React 19.

A scoped theme layer (`swagger-theme.css`, all rules under `#swagger-ui`) maps Swagger's surfaces onto the platform's design tokens so the page is readable in both themes. A 30-line `types/swagger-ui-dist.d.ts` declares just the surface the page uses, rather than pulling in `@types/swagger-ui-dist`.

## Verification
`npx tsc --noEmit` clean, `npm run lint` clean, `npm run build` exits 0 with both new routes in the manifest.

## Summary by Sourcery

Add a member-gated API reference page within the platform that serves Swagger-based docs for the Data API using a server-side spec proxy.

New Features:
- Introduce an internal /platform/api-docs page that renders Swagger UI for the SportsDataverse Data API to signed-in org members.
- Expose a member-gated /api/platform/openapi endpoint that proxies and caches the OpenAPI spec from the Data API without exposing the admin key to browsers.

Enhancements:
- Update the platform navigation to point the API Docs entry to the new internal docs page instead of the external docs site.
- Add a scoped Swagger UI theme to align the API docs page with the platform’s design tokens and support both light and dark themes.
- Provide minimal TypeScript declarations for swagger-ui-dist’s ES bundle to satisfy type-checking without adding the full DefinitelyTyped package.

Build:
- Add swagger-ui-dist as a frontend dependency to bundle Swagger UI directly into the app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an in-platform API documentation page with interactive Swagger UI.
  - Added member-authenticated access to the OpenAPI specification.
  - Added API key authorization and interactive request execution.
  - Updated platform navigation to open the new internal API Docs page.
  - Added loading, error, and setup guidance when documentation cannot be loaded.
- **Style**
  - Applied platform-themed styling, including dark-mode support, to the API reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->