### PR TITLE
fix(packages): resolve flagship cheat-sheet links by repoType

### DIFF
--- a/frontend/components/PackageCard.tsx
+++ b/frontend/components/PackageCard.tsx
@@ -6,7 +6,7 @@ import { Button } from "@components/ui/button";
 import { cheatsheetHref } from "@lib/cheatsheets";
 
 export default function PackageCard({ pkg }: { pkg: any }) {
-  const cheatsheet = cheatsheetHref(pkg.title);
+  const cheatsheet = cheatsheetHref(pkg.title, pkg.repoType);
   return (
     <Card className="group relative h-full overflow-hidden border-transparent bg-card/90 shadow-sm backdrop-blur transition-all duration-300 hover:-translate-y-1 hover:border-primary/40 hover:shadow-xl">
       {/* SDV-blue accent bar */}

--- a/frontend/lib/cheatsheets.ts
+++ b/frontend/lib/cheatsheets.ts
@@ -7,9 +7,6 @@
  */
 
 const CHEATSHEETS: Record<string, string> = {
-  sportsdataversepy: "sportsdataverse-py.pdf",
-  sportsdataversejs: "sportsdataverse-js.pdf",
-  sportsdataverse: "sportsdataverse-R.pdf",
   cfbfastr: "cfbfastR.pdf",
   hoopr: "hoopR.pdf",
   wehoop: "wehoop.pdf",
@@ -24,10 +21,23 @@ const CHEATSHEETS: Record<string, string> = {
   cfbseedr: "cfbplotR-cfb4th-cfbseedR.pdf",
 };
 
-export function cheatsheetHref(title: unknown): string | null {
+/** Flagship metapackage sheets, one per ecosystem, keyed by card repoType. */
+const FLAGSHIP_BY_REPO_TYPE: Record<string, string> = {
+  R: "sportsdataverse-R.pdf",
+  Python: "sportsdataverse-py.pdf",
+  "Node.js": "sportsdataverse-js.pdf",
+};
+
+export function cheatsheetHref(title: unknown, repoType?: unknown): string | null {
   const key = String(title ?? "")
     .toLowerCase()
     .replace(/[^a-z0-9]/g, "");
+  // The flagship cards all title-start with "sportsdataverse" and only differ
+  // by repoType, so the ecosystem — not the title — picks the sheet.
+  if (key.startsWith("sportsdataverse")) {
+    const flagship = FLAGSHIP_BY_REPO_TYPE[String(repoType ?? "")];
+    return flagship ? `/cheatsheets/${flagship}` : null;
+  }
   const file = Object.hasOwn(CHEATSHEETS, key) ? CHEATSHEETS[key] : undefined;
   return file ? `/cheatsheets/${file}` : null;
 }


### PR DESCRIPTION
The three flagship metapackage cards all title-start with `sportsdataverse` and differ only by `repoType`, so the title-normalized map sent the Python and Node.js cards to the R meta sheet. The flagship lookup now branches on `repoType` (`R` / `Python` / `Node.js` per `packageSchema.REPO_TYPES`) regardless of exact title; non-flagship lookups unchanged. Verified all three flagships + a regular card + the inherited-key guard resolve correctly.

## Summary by Sourcery

Bug Fixes:
- Resolve flagship sportsdataverse cheat-sheet links using the card’s repository type so R, Python, and Node.js cards open the correct sheet.